### PR TITLE
Prove +ˡᵐ-comm

### DIFF
--- a/Everything.agda
+++ b/Everything.agda
@@ -4,6 +4,7 @@ import FLA.Algebra.LinearAlgebra.Matrix
 import FLA.Algebra.LinearAlgebra.Properties
 import FLA.Algebra.LinearAlgebra.Properties.Matrix
 import FLA.Algebra.LinearMap
+import FLA.Algebra.LinearMap.Properties
 import FLA.Algebra.Properties.Field
 import FLA.Algebra.Structures
 import FLA.Data.Vec+.Base

--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -47,64 +47,65 @@ _ᵀ : ⦃ F : Field A ⦄ → M A ∶ m × n → M A ∶ n × m
 _·_ : ⦃ F : Field A ⦄ → M A ∶ m × n → Vec A n → Vec A m
 ⟦ f , a , _ ⟧ · x = f ·ˡᵐ x
 
-module MProperties ⦃ F : Field A ⦄ where
-  open Field F
+private
+  module MProperties ⦃ F : Field A ⦄ where
+    open Field F
 
-  _+ᴹ_ : M A ∶ m × n → M A ∶ m × n → M A ∶ m × n
-  ⟦ M₁ , M₁ᵀ , p₁ ⟧ +ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
-    ⟦ M₁ +ˡᵐ M₂
-    , M₁ᵀ +ˡᵐ M₂ᵀ
-    , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
-    ⟧
-    where
-      ⟨⟩-proof : (M₁ M₂ : LinearMap A n m)
-               → (M₁ᵀ M₂ᵀ : LinearMap A m n)
-               → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
-                               → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
-               → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
-                               → ⟨ x , M₂ ·ˡᵐ y ⟩ ≡ ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ )
-               → (x : Vec A m) (y : Vec A n)
-               → ⟨ x , (M₁ +ˡᵐ M₂) ·ˡᵐ y ⟩ ≡ ⟨ y , (M₁ᵀ +ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
-      ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ M₁-proof M₂-proof x y =
-        begin
-          ⟨ x , (M₁ +ˡᵐ M₂) ·ˡᵐ y ⟩             ≡⟨⟩
-          ⟨ x , M₁ ·ˡᵐ y +ⱽ M₂ ·ˡᵐ y ⟩          ≡⟨ ⟨⟩-Properties.⟨x,y+z⟩≡⟨x,y⟩+⟨x,z⟩ x
-                                                   (M₁ ·ˡᵐ y) (M₂ ·ˡᵐ y) ⟩
-          ⟨ x , M₁ ·ˡᵐ y ⟩ + ⟨ x , M₂ ·ˡᵐ y ⟩   ≡⟨ cong (_+ ⟨ x , M₂ ·ˡᵐ y ⟩)
-                                                        (M₁-proof x y) ⟩
-          ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ + ⟨ x , M₂ ·ˡᵐ y ⟩  ≡⟨ cong (⟨ y , M₁ᵀ ·ˡᵐ x ⟩ +_)
-                                                        (M₂-proof x y) ⟩
-          ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ + ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ ≡⟨ sym (⟨⟩-Properties.⟨x,y+z⟩≡⟨x,y⟩+⟨x,z⟩ y
-                                                   (M₁ᵀ ·ˡᵐ x) (M₂ᵀ ·ˡᵐ x)) ⟩
-          ⟨ y , (M₁ᵀ +ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩           ∎
+    _+ᴹ_ : M A ∶ m × n → M A ∶ m × n → M A ∶ m × n
+    ⟦ M₁ , M₁ᵀ , p₁ ⟧ +ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
+      ⟦ M₁ +ˡᵐ M₂
+      , M₁ᵀ +ˡᵐ M₂ᵀ
+      , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
+      ⟧
+      where
+        ⟨⟩-proof : (M₁ M₂ : LinearMap A n m)
+                 → (M₁ᵀ M₂ᵀ : LinearMap A m n)
+                 → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
+                                 → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
+                 → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
+                                 → ⟨ x , M₂ ·ˡᵐ y ⟩ ≡ ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ )
+                 → (x : Vec A m) (y : Vec A n)
+                 → ⟨ x , (M₁ +ˡᵐ M₂) ·ˡᵐ y ⟩ ≡ ⟨ y , (M₁ᵀ +ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
+        ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ M₁-proof M₂-proof x y =
+          begin
+            ⟨ x , (M₁ +ˡᵐ M₂) ·ˡᵐ y ⟩             ≡⟨⟩
+            ⟨ x , M₁ ·ˡᵐ y +ⱽ M₂ ·ˡᵐ y ⟩          ≡⟨ ⟨⟩-Properties.⟨x,y+z⟩≡⟨x,y⟩+⟨x,z⟩ x
+                                                     (M₁ ·ˡᵐ y) (M₂ ·ˡᵐ y) ⟩
+            ⟨ x , M₁ ·ˡᵐ y ⟩ + ⟨ x , M₂ ·ˡᵐ y ⟩   ≡⟨ cong (_+ ⟨ x , M₂ ·ˡᵐ y ⟩)
+                                                          (M₁-proof x y) ⟩
+            ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ + ⟨ x , M₂ ·ˡᵐ y ⟩  ≡⟨ cong (⟨ y , M₁ᵀ ·ˡᵐ x ⟩ +_)
+                                                          (M₂-proof x y) ⟩
+            ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ + ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ ≡⟨ sym (⟨⟩-Properties.⟨x,y+z⟩≡⟨x,y⟩+⟨x,z⟩ y
+                                                     (M₁ᵀ ·ˡᵐ x) (M₂ᵀ ·ˡᵐ x)) ⟩
+            ⟨ y , (M₁ᵀ +ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩           ∎
 
-  _*ᴹ_ : M A ∶ m × n → M A ∶ n × p → M A ∶ m × p
-  ⟦ M₁ , M₁ᵀ , p₁ ⟧ *ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
-    ⟦ M₁ *ˡᵐ M₂
-    , M₂ᵀ *ˡᵐ M₁ᵀ
-    , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
-    ⟧
-    where
-      ⟨⟩-proof : (M₁ : LinearMap A n m) (M₂ : LinearMap A p n)
-               → (M₁ᵀ : LinearMap A m n) (M₂ᵀ : LinearMap A n p)
-               → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
-                               → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
-               → (M₂-⟨⟩-proof : (x : Vec A n) (y : Vec A p)
-                               → ⟨ x , M₂ ·ˡᵐ y ⟩ ≡ ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ )
-               → (x : Vec A m) (y : Vec A p)
-               → ⟨ x , (M₁ *ˡᵐ M₂) ·ˡᵐ y ⟩ ≡ ⟨ y , (M₂ᵀ *ˡᵐ M₁ᵀ) ·ˡᵐ x ⟩
-      ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ M₁-proof M₂-proof x y =
-        begin
-          ⟨ x , (M₁ *ˡᵐ M₂) ·ˡᵐ y ⟩   ≡⟨⟩
-          ⟨ x , M₁ ·ˡᵐ M₂ ·ˡᵐ y ⟩     ≡⟨ M₁-proof x (M₂ ·ˡᵐ y) ⟩
-          ⟨ M₂ ·ˡᵐ y , M₁ᵀ ·ˡᵐ x ⟩    ≡⟨ ⟨⟩-comm (M₂ ·ˡᵐ y) (M₁ᵀ ·ˡᵐ x) ⟩
-          ⟨ M₁ᵀ ·ˡᵐ x , M₂ ·ˡᵐ y ⟩    ≡⟨ M₂-proof (M₁ᵀ ·ˡᵐ x) y ⟩
-          ⟨ y , (M₂ᵀ *ˡᵐ M₁ᵀ) ·ˡᵐ x ⟩ ∎
+    _*ᴹ_ : M A ∶ m × n → M A ∶ n × p → M A ∶ m × p
+    ⟦ M₁ , M₁ᵀ , p₁ ⟧ *ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
+      ⟦ M₁ *ˡᵐ M₂
+      , M₂ᵀ *ˡᵐ M₁ᵀ
+      , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
+      ⟧
+      where
+        ⟨⟩-proof : (M₁ : LinearMap A n m) (M₂ : LinearMap A p n)
+                 → (M₁ᵀ : LinearMap A m n) (M₂ᵀ : LinearMap A n p)
+                 → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
+                                 → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
+                 → (M₂-⟨⟩-proof : (x : Vec A n) (y : Vec A p)
+                                 → ⟨ x , M₂ ·ˡᵐ y ⟩ ≡ ⟨ y , M₂ᵀ ·ˡᵐ x ⟩ )
+                 → (x : Vec A m) (y : Vec A p)
+                 → ⟨ x , (M₁ *ˡᵐ M₂) ·ˡᵐ y ⟩ ≡ ⟨ y , (M₂ᵀ *ˡᵐ M₁ᵀ) ·ˡᵐ x ⟩
+        ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ M₁-proof M₂-proof x y =
+          begin
+            ⟨ x , (M₁ *ˡᵐ M₂) ·ˡᵐ y ⟩   ≡⟨⟩
+            ⟨ x , M₁ ·ˡᵐ M₂ ·ˡᵐ y ⟩     ≡⟨ M₁-proof x (M₂ ·ˡᵐ y) ⟩
+            ⟨ M₂ ·ˡᵐ y , M₁ᵀ ·ˡᵐ x ⟩    ≡⟨ ⟨⟩-comm (M₂ ·ˡᵐ y) (M₁ᵀ ·ˡᵐ x) ⟩
+            ⟨ M₁ᵀ ·ˡᵐ x , M₂ ·ˡᵐ y ⟩    ≡⟨ M₂-proof (M₁ᵀ ·ˡᵐ x) y ⟩
+            ⟨ y , (M₂ᵀ *ˡᵐ M₁ᵀ) ·ˡᵐ x ⟩ ∎
 
-  infixl 6 _+ᴹ_
-  infixl 7 _*ᴹ_
+    infixl 6 _+ᴹ_
+    infixl 7 _*ᴹ_
 
-open MProperties
+open MProperties public
 
 infixr 20 _·_
 infixl 25 _ᵀ

--- a/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
@@ -14,12 +14,11 @@ open import FLA.Axiom.Extensionality.Propositional
 open import FLA.Algebra.Structures
 open import FLA.Algebra.Properties.Field
 open import FLA.Algebra.LinearMap
+open import FLA.Algebra.LinearMap.Properties
 open import FLA.Algebra.LinearAlgebra
 open import FLA.Algebra.LinearAlgebra.Matrix
 
 module FLA.Algebra.LinearAlgebra.Properties.Matrix where
-
-open MProperties
 
 private
   variable
@@ -102,9 +101,30 @@ M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
                → M→M↓ ((L +ᴹ R) ᵀ) ≡ M→M↓ (L ᵀ +ᴹ R ᵀ)
     ᵀ-distr-+↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ , q ⟧ = refl
 
--- Must prove the distribution proofs on LinearMap first.
--- *ᴹ-distr-+ᴹ↓ : {A : Set} ⦃ F : Field A ⦄
---              → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
---              → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
--- *ᴹ-distr-+ᴹ↓ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ = {!!}
--- rewrite *ˡᵐ-distr-+ˡᵐₗ X Y Z | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ = refl
+*ᴹ-distr-+ᴹₗ : {A : Set} ⦃ F : Field A ⦄
+             → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
+             → X *ᴹ (Y +ᴹ Z) ≡ X *ᴹ Y +ᴹ X *ᴹ Z
+*ᴹ-distr-+ᴹₗ X Y Z = M↓≡→M≡ (X *ᴹ (Y +ᴹ Z)) (X *ᴹ Y +ᴹ X *ᴹ Z)
+                             (*ᴹ-distr-+ᴹ↓ₗ X Y Z)
+  where
+    *ᴹ-distr-+ᴹ↓ₗ : {A : Set} ⦃ F : Field A ⦄
+                  → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
+                  → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
+    *ᴹ-distr-+ᴹ↓ₗ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
+        *ˡᵐ-distr-+ˡᵐₗ X Y Z
+      | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ
+      = refl
+
+*ᴹ-distr-+ᴹᵣ : {A : Set} ⦃ F : Field A ⦄
+             → (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
+             → (X +ᴹ Y) *ᴹ Z ≡ X *ᴹ Z +ᴹ Y *ᴹ Z
+*ᴹ-distr-+ᴹᵣ X Y Z = M↓≡→M≡ ((X +ᴹ Y) *ᴹ Z) (X *ᴹ Z +ᴹ Y *ᴹ Z)
+                             (*ᴹ-distr-+ᴹ↓ᵣ X Y Z)
+  where
+    *ᴹ-distr-+ᴹ↓ᵣ : {A : Set} ⦃ F : Field A ⦄
+                  → (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
+                  → M→M↓ ((X +ᴹ Y) *ᴹ Z) ≡ M→M↓ (X *ᴹ Z +ᴹ Y *ᴹ Z)
+    *ᴹ-distr-+ᴹ↓ᵣ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
+        *ˡᵐ-distr-+ˡᵐᵣ X Y Z
+      | *ˡᵐ-distr-+ˡᵐₗ Zᵀ Xᵀ Yᵀ
+      = refl

--- a/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
@@ -72,7 +72,7 @@ M↓→M ⟦ M , Mᵀ ⟧ p = ⟦ M , Mᵀ , p ⟧
     f C Cᵀ p q (x) (y) = uip (p x y) (q x y)
 
 M↓≡→M≡ : ⦃ F : Field A ⦄ → (C D : M A ∶ m × n) → (M→M↓ C ≡ M→M↓ D) → C ≡ D
-M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ l@refl rewrite
+M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
   ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP C Cᵀ p q = refl
 
 
@@ -106,4 +106,5 @@ M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ l@refl rewrite
 -- *ᴹ-distr-+ᴹ↓ : {A : Set} ⦃ F : Field A ⦄
 --              → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
 --              → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
--- *ᴹ-distr-+ᴹ↓ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite *ˡᵐ-distr-+ˡᵐₗ X Y Z | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ = refl
+-- *ᴹ-distr-+ᴹ↓ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ = {!!}
+-- rewrite *ˡᵐ-distr-+ˡᵐₗ X Y Z | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ = refl

--- a/src/FLA/Algebra/LinearMap.agda
+++ b/src/FLA/Algebra/LinearMap.agda
@@ -4,8 +4,9 @@
 -- for the fields that we want (real numbers)
 open import Level using (Level)
 
-open import Relation.Binary.PropositionalEquality hiding (∀-extensionality)
+open import Relation.Binary.PropositionalEquality hiding (Extensionality)
 open ≡-Reasoning
+
 
 open import Data.Nat using (ℕ; suc; zero)
 open import Data.Vec using (Vec; foldr; zipWith; map)
@@ -37,13 +38,8 @@ record LinearMap (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
     -- Homogeneity
     f[c*v]≡c*f[v] : (c : A) → (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v)
 
-
 _·ˡᵐ_ : ⦃ F : Field A ⦄ → LinearMap A m n → Vec A m → Vec A n
 _·ˡᵐ_ LM = LinearMap.f LM
-
--- Choose 20 since function application is assumed higher than almost anything
-infixr 20 _·ˡᵐ_
-
 
 _+ˡᵐ_ : ⦃ F : Field A ⦄ → LinearMap A m n → LinearMap A m n → LinearMap A m n
 g +ˡᵐ h = record
@@ -104,28 +100,9 @@ g *ˡᵐ h = record
 
 infixl 6 _+ˡᵐ_
 infixl 7 _*ˡᵐ_
+-- Choose 20 since function application is assumed higher than almost anything
+infixr 20 _·ˡᵐ_
 
-
--------------------------------------------------------------------------------
---                           LinearMap constructor                           --
--------------------------------------------------------------------------------
-
-
--- If I can prove these two I can prove the distributive property on
--- matrices below.
--- +ˡᵐ-comm : ⦃ F : Field A ⦄ → (L R : LinearMap A m n)
---          → L +ˡᵐ R ≡ R +ˡᵐ L
--- +ˡᵐ-comm L R = {!!}
-
--- *ˡᵐ-distr-+ˡᵐₗ : ⦃ F : Field A ⦄
---                → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
---                → X *ˡᵐ (Y +ˡᵐ Z) ≡ X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z
--- *ˡᵐ-distr-+ˡᵐₗ X Y Z = {!!}
-
--- *ˡᵐ-distr-+ˡᵐᵣ : ⦃ F : Field A ⦄
---                → (X Y : LinearMap A n m) → (Z : LinearMap A p n)
---                → (X +ˡᵐ Y) *ˡᵐ Z ≡ X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z
--- *ˡᵐ-distr-+ˡᵐᵣ X Y Z = {!!}
 
 -- Example LinearMap values ---------------------------------------------------
 

--- a/src/FLA/Algebra/LinearMap/Properties.agda
+++ b/src/FLA/Algebra/LinearMap/Properties.agda
@@ -1,0 +1,130 @@
+{-# OPTIONS --with-K #-}
+
+open import Level using (Level)
+
+open import Axiom.UniquenessOfIdentityProofs.WithK using (uip)
+
+open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open ≡-Reasoning
+
+
+open import Data.Nat using (ℕ)
+open import Data.Vec using (Vec)
+
+open import FLA.Axiom.Extensionality.Propositional
+open import FLA.Algebra.Structures
+open import FLA.Algebra.LinearAlgebra
+open import FLA.Algebra.LinearAlgebra.Properties
+open import FLA.Algebra.LinearMap
+
+module FLA.Algebra.LinearMap.Properties where
+
+private
+  variable
+    ℓ : Level
+    A : Set ℓ
+    m n p q : ℕ
+    ⦃ F ⦄ : Field A
+
+-------------------------------------------------------------------------------
+--                  LinearMap without the proofs: LinearMap↓                 --
+-------------------------------------------------------------------------------
+
+private
+  data LinearMap↓ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
+    LM↓ : (Vec A m → Vec A n) → LinearMap↓ A m n
+
+  _·ˡᵐ↓_ : ⦃ F : Field A ⦄ → LinearMap↓ A m n → Vec A m → Vec A n
+  _·ˡᵐ↓_ (LM↓ f) = f
+
+  -- Choose 20 since function application is assumed higher than almost anything
+  infixr 20 _·ˡᵐ↓_
+
+  L→L↓ : ⦃ F : Field A ⦄ → LinearMap A m n → LinearMap↓ A m n
+  L→L↓ record { f = f } = LM↓ f
+
+  L↓→L : ⦃ F : Field A ⦄
+        → (L↓ : LinearMap↓ A m n)
+        → (f[u+v]≡f[u]+f[v] : (u v : Vec A m)
+                             → L↓ ·ˡᵐ↓ (u +ⱽ v) ≡ L↓ ·ˡᵐ↓ u +ⱽ L↓ ·ˡᵐ↓ v)
+        → (f[c*v]≡c*f[v] : (c : A) → (v : Vec A m)
+                          → L↓ ·ˡᵐ↓ (c *ᶜ v) ≡ c *ᶜ (L↓ ·ˡᵐ↓ v))
+        → LinearMap A m n
+  L↓→L (LM↓ f) f[u+v]≡f[u]+f[v] f[c*v]≡c*f[v] =
+    record
+      { f = f
+      ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]
+      ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]
+      }
+
+  f[u+v]≡f[u]+f[v]-UIP : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
+    → (f : Vec A m → Vec A n)
+    → (p q : (u v : Vec A m)
+            → f (u +ⱽ v) ≡ f u +ⱽ f v)
+    → p ≡ q
+  f[u+v]≡f[u]+f[v]-UIP f p q =
+    extensionality (λ u → extensionality (λ v → t f p q u v))
+    where
+      t : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
+        → (f : Vec A m → Vec A n)
+        → (p q : (u v : Vec A m)
+                → f (u +ⱽ v) ≡ f u +ⱽ f v)
+        → (u v : Vec A m) → p u v ≡ q u v
+      t f p q u v = uip (p u v) (q u v)
+
+  f[c*v]≡c*f[v]-UIP : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
+                    → (f : Vec A m → Vec A n)
+                    → (p q : (c : A) (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v))
+                    → p ≡ q
+  f[c*v]≡c*f[v]-UIP f p q =
+    extensionality (λ c → extensionality (λ v → t f p q c v))
+    where
+      t : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
+        → (f : Vec A m → Vec A n)
+        → (p q : (c : A) (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v))
+        → (c : A) (v : Vec A m) → p c v ≡ q c v
+      t f p q c v = uip (p c v) (q c v)
+
+  L↓≡→L≡ : ⦃ F : Field A ⦄ → (C D : LinearMap A m n)
+          → (L→L↓ C ≡ L→L↓ D) → C ≡ D
+  L↓≡→L≡ record { f = f
+                 ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]ᶜ
+                 ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]ᶜ
+                 }
+          record { f = .f
+                 ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]ᵈ
+                 ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]ᵈ
+                 }
+          refl
+    rewrite
+      f[u+v]≡f[u]+f[v]-UIP f f[u+v]≡f[u]+f[v]ᶜ f[u+v]≡f[u]+f[v]ᵈ
+    | f[c*v]≡c*f[v]-UIP f f[c*v]≡c*f[v]ᶜ f[c*v]≡c*f[v]ᵈ
+    = refl
+
+
+-------------------------------------------------------------------------------
+--                   LinearMap Proofs via LinearMap↓ Proofs                  --
+-------------------------------------------------------------------------------
+
++ˡᵐ-comm : ⦃ F : Field A ⦄ → (L R : LinearMap A m n)
+         → L +ˡᵐ R ≡ R +ˡᵐ L
++ˡᵐ-comm L R = L↓≡→L≡ (L +ˡᵐ R) (R +ˡᵐ L) (+ˡᵐ-comm↓ L R)
+  where
+    z : ⦃ F : Field A ⦄
+      → (f g : Vec A m → Vec A n)
+      → (λ v → f v +ⱽ g v) ≡ (λ v → g v +ⱽ f v)
+    z f g = extensionality (λ v → +ⱽ-comm (f v) (g v))
+
+    +ˡᵐ-comm↓ : ⦃ F : Field A ⦄ → (L R : LinearMap A m n)
+             → L→L↓ (L +ˡᵐ R) ≡ L→L↓ (R +ˡᵐ L)
+    +ˡᵐ-comm↓ L R = cong LM↓ (z (LinearMap.f L) (LinearMap.f R))
+
+-- *ˡᵐ-distr-+ˡᵐₗ : ⦃ F : Field A ⦄
+--                → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
+--                → X *ˡᵐ (Y +ˡᵐ Z) ≡ X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z
+-- *ˡᵐ-distr-+ˡᵐₗ X Y Z = {!!}
+
+-- *ˡᵐ-distr-+ˡᵐᵣ : ⦃ F : Field A ⦄
+--                → (X Y : LinearMap A n m) → (Z : LinearMap A p n)
+--                → (X +ˡᵐ Y) *ˡᵐ Z ≡ X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z
+-- *ˡᵐ-distr-+ˡᵐᵣ X Y Z = {!!}

--- a/src/FLA/Algebra/LinearMap/Properties.agda
+++ b/src/FLA/Algebra/LinearMap/Properties.agda
@@ -110,21 +110,40 @@ private
          → L +ˡᵐ R ≡ R +ˡᵐ L
 +ˡᵐ-comm L R = L↓≡→L≡ (L +ˡᵐ R) (R +ˡᵐ L) (+ˡᵐ-comm↓ L R)
   where
-    z : ⦃ F : Field A ⦄
+    +ⱽ-comm-ext : ⦃ F : Field A ⦄
       → (f g : Vec A m → Vec A n)
       → (λ v → f v +ⱽ g v) ≡ (λ v → g v +ⱽ f v)
-    z f g = extensionality (λ v → +ⱽ-comm (f v) (g v))
+    +ⱽ-comm-ext f g = extensionality (λ v → +ⱽ-comm (f v) (g v))
 
     +ˡᵐ-comm↓ : ⦃ F : Field A ⦄ → (L R : LinearMap A m n)
              → L→L↓ (L +ˡᵐ R) ≡ L→L↓ (R +ˡᵐ L)
-    +ˡᵐ-comm↓ L R = cong LM↓ (z (LinearMap.f L) (LinearMap.f R))
+    +ˡᵐ-comm↓ L R = cong LM↓ (+ⱽ-comm-ext (LinearMap.f L) (LinearMap.f R))
 
--- *ˡᵐ-distr-+ˡᵐₗ : ⦃ F : Field A ⦄
---                → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
---                → X *ˡᵐ (Y +ˡᵐ Z) ≡ X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z
--- *ˡᵐ-distr-+ˡᵐₗ X Y Z = {!!}
+*ˡᵐ-distr-+ˡᵐₗ : ⦃ F : Field A ⦄
+               → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
+               → (X *ˡᵐ (Y +ˡᵐ Z)) ≡ (X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z)
+*ˡᵐ-distr-+ˡᵐₗ X Y Z = L↓≡→L≡ (X *ˡᵐ (Y +ˡᵐ Z)) ((X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z))
+                               (*ˡᵐ-distr-+ˡᵐₗ↓ X Y Z)
+  where
+    *-distr-+ⱽ : ⦃ F : Field A ⦄
+      → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
+      → (λ v → X ·ˡᵐ (Y ·ˡᵐ v +ⱽ Z ·ˡᵐ v)) ≡
+         (λ v → X ·ˡᵐ (Y ·ˡᵐ v) +ⱽ X ·ˡᵐ (Z ·ˡᵐ v))
+    *-distr-+ⱽ X Y Z = extensionality
+      (λ v → LinearMap.f[u+v]≡f[u]+f[v] X (Y ·ˡᵐ v) (Z ·ˡᵐ v))
 
--- *ˡᵐ-distr-+ˡᵐᵣ : ⦃ F : Field A ⦄
---                → (X Y : LinearMap A n m) → (Z : LinearMap A p n)
---                → (X +ˡᵐ Y) *ˡᵐ Z ≡ X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z
--- *ˡᵐ-distr-+ˡᵐᵣ X Y Z = {!!}
+    *ˡᵐ-distr-+ˡᵐₗ↓ : ⦃ F : Field A ⦄
+                    → (X : LinearMap A n m) → (Y Z : LinearMap A p n)
+                    → L→L↓ (X *ˡᵐ (Y +ˡᵐ Z)) ≡ L→L↓ (X *ˡᵐ Y +ˡᵐ X *ˡᵐ Z)
+    *ˡᵐ-distr-+ˡᵐₗ↓ X Y Z = cong LM↓ (*-distr-+ⱽ X Y Z)
+
+*ˡᵐ-distr-+ˡᵐᵣ : ⦃ F : Field A ⦄
+               → (X Y : LinearMap A n m) → (Z : LinearMap A p n)
+               → (X +ˡᵐ Y) *ˡᵐ Z ≡ X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z
+*ˡᵐ-distr-+ˡᵐᵣ X Y Z = L↓≡→L≡ ((X +ˡᵐ Y) *ˡᵐ Z) (X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z)
+                               (*ˡᵐ-distr-+ˡᵐᵣ↓ X Y Z)
+  where
+    *ˡᵐ-distr-+ˡᵐᵣ↓ : ⦃ F : Field A ⦄
+                    → (X Y : LinearMap A n m) → (Z : LinearMap A p n)
+                    → L→L↓ ((X +ˡᵐ Y) *ˡᵐ Z) ≡ L→L↓ (X *ˡᵐ Z +ˡᵐ Y *ˡᵐ Z)
+    *ˡᵐ-distr-+ˡᵐᵣ↓ X Y Z = cong LM↓ refl


### PR DESCRIPTION
Start the proofs on `LinearMap`s, which extend to the proofs of matrices later on. The proofs require  dependent function extensionality and thus are not safe in Agda's eyes, but extensionality is consistent with the theory behind Agda. It would be possible to use cubical agda (HoTT) to prove extensionality directly but then the Uniqueness of Identity Proofs (UIP) is not readily transferable. 