### PR TITLE
Rename LinearMap to ⊸

### DIFF
--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -34,8 +34,8 @@ private
 -------------------------------------------------------------------------------
 
 data M_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
-  ⟦_,_,_⟧ : (M : LinearMap A n m )
-          → (Mᵀ : LinearMap A m n )
+  ⟦_,_,_⟧ : (M : n ⊸ m )
+          → (Mᵀ : m ⊸ n )
           → (p : (x : Vec A m) → (y : Vec A n)
                → ⟨ x , M ·ˡᵐ y ⟩ ≡ ⟨ y , Mᵀ ·ˡᵐ x ⟩ )
           → M A ∶ m × n
@@ -58,7 +58,7 @@ module _ where
 
 module _ ⦃ F : Field A ⦄ where
   open Field F
-  open LinearMap
+  open _⊸_
 
   _+ᴹ_ : M A ∶ m × n → M A ∶ m × n → M A ∶ m × n
   ⟦ M₁ , M₁ᵀ , p₁ ⟧ +ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
@@ -67,8 +67,8 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : (M₁ M₂ : LinearMap A n m)
-               → (M₁ᵀ M₂ᵀ : LinearMap A m n)
+      ⟨⟩-proof : (M₁ M₂ : n ⊸ m)
+               → (M₁ᵀ M₂ᵀ : m ⊸ n)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
@@ -97,8 +97,8 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : (M₁ : LinearMap A n m) (M₂ : LinearMap A p n)
-               → (M₁ᵀ : LinearMap A m n) (M₂ᵀ : LinearMap A n p)
+      ⟨⟩-proof : (M₁ : n ⊸ m) (M₂ : p ⊸ n)
+               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : n ⊸ p)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A n) (y : Vec A p)
@@ -120,8 +120,8 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : {m n p : ℕ} → (M₁ : LinearMap A n m) (M₂ : LinearMap A p m)
-               → (M₁ᵀ : LinearMap A m n) (M₂ᵀ : LinearMap A m p)
+      ⟨⟩-proof : {m n p : ℕ} → (M₁ : n ⊸ m) (M₂ : p ⊸ m)
+               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : m ⊸ p)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A p)
@@ -157,8 +157,9 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : {m n p q : ℕ} → (M₁ : LinearMap A n m) (M₂ : LinearMap A q p)
-               → (M₁ᵀ : LinearMap A m n) (M₂ᵀ : LinearMap A p q)
+      ⟨⟩-proof : {m n p q : ℕ}
+               → (M₁ : n ⊸ m) (M₂ : q ⊸ p)
+               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : p ⊸ q)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A p) (y : Vec A q)

--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -67,8 +67,7 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : (M₁ M₂ : n ⊸ m)
-               → (M₁ᵀ M₂ᵀ : m ⊸ n)
+      ⟨⟩-proof : (M₁ M₂ : n ⊸ m) (M₁ᵀ M₂ᵀ : m ⊸ n)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
@@ -97,8 +96,7 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : (M₁ : n ⊸ m) (M₂ : p ⊸ n)
-               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : n ⊸ p)
+      ⟨⟩-proof : (M₁ : n ⊸ m) (M₂ : p ⊸ n) (M₁ᵀ : m ⊸ n) (M₂ᵀ : n ⊸ p)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A n) (y : Vec A p)
@@ -120,8 +118,8 @@ module _ ⦃ F : Field A ⦄ where
     , ⟨⟩-proof M₁ M₂ M₁ᵀ M₂ᵀ p₁ p₂
     ⟧
     where
-      ⟨⟩-proof : {m n p : ℕ} → (M₁ : n ⊸ m) (M₂ : p ⊸ m)
-               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : m ⊸ p)
+      ⟨⟩-proof : {m n p : ℕ}
+               → (M₁ : n ⊸ m) (M₂ : p ⊸ m) (M₁ᵀ : m ⊸ n) (M₂ᵀ : m ⊸ p)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A m) (y : Vec A p)
@@ -158,8 +156,7 @@ module _ ⦃ F : Field A ⦄ where
     ⟧
     where
       ⟨⟩-proof : {m n p q : ℕ}
-               → (M₁ : n ⊸ m) (M₂ : q ⊸ p)
-               → (M₁ᵀ : m ⊸ n) (M₂ᵀ : p ⊸ q)
+               → (M₁ : n ⊸ m) (M₂ : q ⊸ p) (M₁ᵀ : m ⊸ n) (M₂ᵀ : p ⊸ q)
                → (M₁-⟨⟩-proof : (x : Vec A m) (y : Vec A n)
                                → ⟨ x , M₁ ·ˡᵐ y ⟩ ≡ ⟨ y , M₁ᵀ ·ˡᵐ x ⟩ )
                → (M₂-⟨⟩-proof : (x : Vec A p) (y : Vec A q)

--- a/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
@@ -31,100 +31,99 @@ private
 --                   M without the inner product proof: M↓                   --
 -------------------------------------------------------------------------------
 
-data M↓_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
-  ⟦_,_⟧ : (M : LinearMap A n m ) → (Mᵀ : LinearMap A m n ) → M↓ A ∶ m × n
+private
+  data M↓_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
+    ⟦_,_⟧ : (M : n ⊸ m ) → (Mᵀ : m ⊸ n ) → M↓ A ∶ m × n
 
-_·↓_ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → Vec A n → Vec A m
-⟦ f , a ⟧ ·↓ x = f ·ˡᵐ x
+  _·↓_ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → Vec A n → Vec A m
+  ⟦ f , a ⟧ ·↓ x = f ·ˡᵐ x
 
-_ᵀ↓ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → M↓ A ∶ n × m
-⟦ f , a ⟧ ᵀ↓ = ⟦ a , f ⟧
+  _ᵀ↓ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → M↓ A ∶ n × m
+  ⟦ f , a ⟧ ᵀ↓ = ⟦ a , f ⟧
 
-infixr 20 _·↓_
-infixl 25 _ᵀ↓
+  infixr 20 _·↓_
+  infixl 25 _ᵀ↓
 
-M→M↓ : ⦃ F : Field A ⦄ → M A ∶ m × n → M↓ A ∶ m × n
-M→M↓ ⟦ M , Mᵀ , p ⟧ = ⟦ M , Mᵀ ⟧
+  M→M↓ : ⦃ F : Field A ⦄ → M A ∶ m × n → M↓ A ∶ m × n
+  M→M↓ ⟦ M , Mᵀ , p ⟧ = ⟦ M , Mᵀ ⟧
 
-M↓→M : ⦃ F : Field A ⦄
-      → (M↓ : M↓ A ∶ m × n)
-      → (p : (x : Vec A m) → (y : Vec A n)
-            → ⟨ x , M↓ ·↓ y ⟩ ≡ ⟨ y , M↓ ᵀ↓ ·↓ x ⟩ )
-      → M A ∶ m × n
-M↓→M ⟦ M , Mᵀ ⟧ p = ⟦ M , Mᵀ , p ⟧
+  M↓→M : ⦃ F : Field A ⦄
+        → (M↓ : M↓ A ∶ m × n)
+        → (p : (x : Vec A m) → (y : Vec A n)
+              → ⟨ x , M↓ ·↓ y ⟩ ≡ ⟨ y , M↓ ᵀ↓ ·↓ x ⟩ )
+        → M A ∶ m × n
+  M↓→M ⟦ M , Mᵀ ⟧ p = ⟦ M , Mᵀ , p ⟧
 
-⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP : {ℓ : Level} → {A : Set ℓ} → ⦃ F : Field A ⦄
-                   → (C : LinearMap A n m) → (Cᵀ : LinearMap A m n)
-                   → (p q : (x : Vec A m) (y : Vec A n)
-                           → ⟨ x , C ·ˡᵐ y ⟩ ≡ ⟨ y , Cᵀ ·ˡᵐ x ⟩)
-                   → p ≡ q
-⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP {m} {n} {ℓ} {A} C Cᵀ p q =
-  extensionality (λ x → extensionality (λ y → f C Cᵀ p q x y))
-  where
-    f : {m n : ℕ}
-          → {A : Set ℓ}
-          → ⦃ F : Field A ⦄
-          → (C : LinearMap A n m) → (Cᵀ : LinearMap A m n)
-          → (p q : (x : Vec A m) (y : Vec A n)
-                  → ⟨ x , C ·ˡᵐ y ⟩ ≡ ⟨ y , Cᵀ ·ˡᵐ x ⟩)
-          → (x : Vec A m) →  (y : Vec A n) → p x y ≡ q x y
-    f C Cᵀ p q (x) (y) = uip (p x y) (q x y)
+  ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP : {ℓ : Level} → {A : Set ℓ} → ⦃ F : Field A ⦄
+                    → (C : n ⊸ m) → (Cᵀ : m ⊸ n)
+                    → (p q : (x : Vec A m) (y : Vec A n)
+                            → ⟨ x , C ·ˡᵐ y ⟩ ≡ ⟨ y , Cᵀ ·ˡᵐ x ⟩)
+                    → p ≡ q
+  ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP {m} {n} {ℓ} {A} C Cᵀ p q =
+    extensionality (λ x → extensionality (λ y → f C Cᵀ p q x y))
+    where
+      f : {m n : ℕ}
+            → {A : Set ℓ}
+            → ⦃ F : Field A ⦄
+            → (C : n ⊸ m) → (Cᵀ : m ⊸ n)
+            → (p q : (x : Vec A m) (y : Vec A n)
+                    → ⟨ x , C ·ˡᵐ y ⟩ ≡ ⟨ y , Cᵀ ·ˡᵐ x ⟩)
+            → (x : Vec A m) →  (y : Vec A n) → p x y ≡ q x y
+      f C Cᵀ p q (x) (y) = uip (p x y) (q x y)
 
-M↓≡→M≡ : ⦃ F : Field A ⦄ → (C D : M A ∶ m × n) → (M→M↓ C ≡ M→M↓ D) → C ≡ D
-M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
-  ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP C Cᵀ p q = refl
+  M↓≡→M≡ : ⦃ F : Field A ⦄ → (C D : M A ∶ m × n) → (M→M↓ C ≡ M→M↓ D) → C ≡ D
+  M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
+    ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP C Cᵀ p q = refl
 
 
 -------------------------------------------------------------------------------
 --                                Proofs on M                                --
 -------------------------------------------------------------------------------
 
-ᵀᵀ : {A : Set} ⦃ F : Field A ⦄ → (B : M A ∶ m × n) → B ᵀ ᵀ ≡ B
-ᵀᵀ B = M↓≡→M≡ (B ᵀ ᵀ) B (ᵀᵀ↓ B)
-  where
-    ᵀᵀ↓ : {A : Set} ⦃ F : Field A ⦄ → (B : M A ∶ m × n) → M→M↓ (B ᵀ ᵀ) ≡ M→M↓ B
-    ᵀᵀ↓ ⟦ M , Mᵀ , p ⟧ = refl
+module _ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ where
+  open Field F
 
-ᵀ-distr-* : {A : Set} ⦃ F : Field A ⦄ → (L : M A ∶ m × n) (R : M A ∶ n × p)
-          → (L *ᴹ R) ᵀ ≡ (R ᵀ *ᴹ L ᵀ)
-ᵀ-distr-* L R = M↓≡→M≡ ((L *ᴹ R) ᵀ) (R ᵀ *ᴹ L ᵀ) (ᵀ-distr-*↓ L R)
-  where
-    ᵀ-distr-*↓ : {A : Set} ⦃ F : Field A ⦄ → (L : M A ∶ m × n) (R : M A ∶ n × p)
-               → M→M↓ ((L *ᴹ R) ᵀ) ≡ M→M↓ (R ᵀ *ᴹ L ᵀ)
-    ᵀ-distr-*↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ₁ , q ⟧ = refl
+  ᵀᵀ : (B : M A ∶ m × n) → B ᵀ ᵀ ≡ B
+  ᵀᵀ B = M↓≡→M≡ (B ᵀ ᵀ) B (ᵀᵀ↓ B)
+    where
+      ᵀᵀ↓ : (B : M A ∶ m × n) → M→M↓ (B ᵀ ᵀ) ≡ M→M↓ B
+      ᵀᵀ↓ ⟦ M , Mᵀ , p ⟧ = refl
 
-ᵀ-distr-+ : {A : Set} ⦃ F : Field A ⦄ → (L R : M A ∶ m × n)
-           → (L +ᴹ R) ᵀ ≡ L ᵀ +ᴹ R ᵀ
-ᵀ-distr-+ L R = M↓≡→M≡ ((L +ᴹ R) ᵀ) (L ᵀ +ᴹ R ᵀ) (ᵀ-distr-+↓ L R)
-  where
-    ᵀ-distr-+↓ : {A : Set} ⦃ F : Field A ⦄ → (L R : M A ∶ m × n)
-               → M→M↓ ((L +ᴹ R) ᵀ) ≡ M→M↓ (L ᵀ +ᴹ R ᵀ)
-    ᵀ-distr-+↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ , q ⟧ = refl
+  ᵀ-distr-* : (L : M A ∶ m × n) (R : M A ∶ n × p)
+            → (L *ᴹ R) ᵀ ≡ (R ᵀ *ᴹ L ᵀ)
+  ᵀ-distr-* L R = M↓≡→M≡ ((L *ᴹ R) ᵀ) (R ᵀ *ᴹ L ᵀ) (ᵀ-distr-*↓ L R)
+    where
+      ᵀ-distr-*↓ : (L : M A ∶ m × n) (R : M A ∶ n × p)
+                → M→M↓ ((L *ᴹ R) ᵀ) ≡ M→M↓ (R ᵀ *ᴹ L ᵀ)
+      ᵀ-distr-*↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ₁ , q ⟧ = refl
 
-*ᴹ-distr-+ᴹₗ : {A : Set} ⦃ F : Field A ⦄
-             → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
-             → X *ᴹ (Y +ᴹ Z) ≡ X *ᴹ Y +ᴹ X *ᴹ Z
-*ᴹ-distr-+ᴹₗ X Y Z = M↓≡→M≡ (X *ᴹ (Y +ᴹ Z)) (X *ᴹ Y +ᴹ X *ᴹ Z)
-                             (*ᴹ-distr-+ᴹ↓ₗ X Y Z)
-  where
-    *ᴹ-distr-+ᴹ↓ₗ : {A : Set} ⦃ F : Field A ⦄
-                  → (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
-                  → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
-    *ᴹ-distr-+ᴹ↓ₗ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
-        *ˡᵐ-distr-+ˡᵐₗ X Y Z
-      | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ
-      = refl
+  ᵀ-distr-+ : (L R : M A ∶ m × n) → (L +ᴹ R) ᵀ ≡ L ᵀ +ᴹ R ᵀ
+  ᵀ-distr-+ L R = M↓≡→M≡ ((L +ᴹ R) ᵀ) (L ᵀ +ᴹ R ᵀ) (ᵀ-distr-+↓ L R)
+    where
+      ᵀ-distr-+↓ : (L R : M A ∶ m × n)
+                 → M→M↓ ((L +ᴹ R) ᵀ) ≡ M→M↓ (L ᵀ +ᴹ R ᵀ)
+      ᵀ-distr-+↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ , q ⟧ = refl
 
-*ᴹ-distr-+ᴹᵣ : {A : Set} ⦃ F : Field A ⦄
-             → (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
-             → (X +ᴹ Y) *ᴹ Z ≡ X *ᴹ Z +ᴹ Y *ᴹ Z
-*ᴹ-distr-+ᴹᵣ X Y Z = M↓≡→M≡ ((X +ᴹ Y) *ᴹ Z) (X *ᴹ Z +ᴹ Y *ᴹ Z)
-                             (*ᴹ-distr-+ᴹ↓ᵣ X Y Z)
-  where
-    *ᴹ-distr-+ᴹ↓ᵣ : {A : Set} ⦃ F : Field A ⦄
-                  → (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
-                  → M→M↓ ((X +ᴹ Y) *ᴹ Z) ≡ M→M↓ (X *ᴹ Z +ᴹ Y *ᴹ Z)
-    *ᴹ-distr-+ᴹ↓ᵣ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
-        *ˡᵐ-distr-+ˡᵐᵣ X Y Z
-      | *ˡᵐ-distr-+ˡᵐₗ Zᵀ Xᵀ Yᵀ
-      = refl
+  *ᴹ-distr-+ᴹₗ : (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
+               → X *ᴹ (Y +ᴹ Z) ≡ X *ᴹ Y +ᴹ X *ᴹ Z
+  *ᴹ-distr-+ᴹₗ X Y Z = M↓≡→M≡ (X *ᴹ (Y +ᴹ Z)) (X *ᴹ Y +ᴹ X *ᴹ Z)
+                              (*ᴹ-distr-+ᴹ↓ₗ X Y Z)
+    where
+      *ᴹ-distr-+ᴹ↓ₗ : (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
+                    → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
+      *ᴹ-distr-+ᴹ↓ₗ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
+          *ˡᵐ-distr-+ˡᵐₗ X Y Z
+        | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ
+        = refl
+
+  *ᴹ-distr-+ᴹᵣ : (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
+               → (X +ᴹ Y) *ᴹ Z ≡ X *ᴹ Z +ᴹ Y *ᴹ Z
+  *ᴹ-distr-+ᴹᵣ X Y Z = M↓≡→M≡ ((X +ᴹ Y) *ᴹ Z) (X *ᴹ Z +ᴹ Y *ᴹ Z)
+                              (*ᴹ-distr-+ᴹ↓ᵣ X Y Z)
+    where
+      *ᴹ-distr-+ᴹ↓ᵣ : (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
+                    → M→M↓ ((X +ᴹ Y) *ᴹ Z) ≡ M→M↓ (X *ᴹ Z +ᴹ Y *ᴹ Z)
+      *ᴹ-distr-+ᴹ↓ᵣ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
+          *ˡᵐ-distr-+ˡᵐᵣ X Y Z
+        | *ˡᵐ-distr-+ˡᵐₗ Zᵀ Xᵀ Yᵀ
+        = refl

--- a/src/FLA/Algebra/LinearMap.agda
+++ b/src/FLA/Algebra/LinearMap.agda
@@ -90,17 +90,16 @@ module _ ⦃ F : Field A ⦄ where
     ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]' g h
     }
     where
-      f[u+v]≡f[u]+f[v]' : (g : n ⊸ p)
-                        → (h : m ⊸ n)
+      f[u+v]≡f[u]+f[v]' : (g : n ⊸ p) (h : m ⊸ n)
                         → (u v : Vec A m)
-                        → g ·ˡᵐ (h ·ˡᵐ (u +ⱽ v)) ≡ g ·ˡᵐ (h ·ˡᵐ u) +ⱽ g ·ˡᵐ (h ·ˡᵐ v)
+                        → g ·ˡᵐ (h ·ˡᵐ (u +ⱽ v)) ≡
+                           g ·ˡᵐ (h ·ˡᵐ u) +ⱽ g ·ˡᵐ (h ·ˡᵐ v)
       f[u+v]≡f[u]+f[v]' g h u v rewrite
           f[u+v]≡f[u]+f[v] h u v
         | f[u+v]≡f[u]+f[v] g (f h u) (f h v)
         = refl
   
-      f[c*v]≡c*f[v]' : (g : n ⊸ p)
-                     → (h : m ⊸ n)
+      f[c*v]≡c*f[v]' : (g : n ⊸ p) (h : m ⊸ n)
                      → (c : A) (v : Vec A m)
                      → g ·ˡᵐ (h ·ˡᵐ (c *ᶜ v)) ≡ c *ᶜ g ·ˡᵐ (h ·ˡᵐ v)
       f[c*v]≡c*f[v]' g h c v rewrite
@@ -117,7 +116,7 @@ module _ ⦃ F : Field A ⦄ where
       ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]' T B
       }
     where
-      f[u+v]≡f[u]+f[v]' : (T : p ⊸ m) → (B : p ⊸ n)
+      f[u+v]≡f[u]+f[v]' : (T : p ⊸ m) (B : p ⊸ n)
                         → (u v : Vec A p)
                         → T ·ˡᵐ (u +ⱽ v) ++ B ·ˡᵐ (u +ⱽ v) ≡
                           (T ·ˡᵐ u ++ B ·ˡᵐ u) +ⱽ (T ·ˡᵐ v ++ B ·ˡᵐ v)
@@ -127,7 +126,7 @@ module _ ⦃ F : Field A ⦄ where
         | +ⱽ-flip-++ (T ·ˡᵐ u) (T ·ˡᵐ v) (B ·ˡᵐ u) (B ·ˡᵐ v)
         = refl
 
-      f[c*v]≡c*f[v]' : (T : p ⊸ m) → (B : p ⊸ n)
+      f[c*v]≡c*f[v]' : (T : p ⊸ m) (B : p ⊸ n)
                      → (c : A) → (v : Vec A p)
                      → T ·ˡᵐ (c *ᶜ v) ++ B ·ˡᵐ (c *ᶜ v) ≡
                         c *ᶜ (T ·ˡᵐ v ++ B ·ˡᵐ v)
@@ -147,7 +146,7 @@ module _ ⦃ F : Field A ⦄ where
       }
       where
         f[u+v]≡f[u]+f[v]' : {m n p : ℕ}
-                          → (T : m ⊸ p) → (B : n ⊸ p)
+                          → (T : m ⊸ p) (B : n ⊸ p)
                           → (u v : Vec A (m +ᴺ n))
                           → T ·ˡᵐ take m (u +ⱽ v) +ⱽ B ·ˡᵐ drop m (u +ⱽ v) ≡
                              T ·ˡᵐ take m u +ⱽ B ·ˡᵐ drop m u +ⱽ
@@ -212,7 +211,7 @@ module _ ⦃ F : Field A ⦄ where
       }
       where
         f[u+v]≡f[u]+f[v]' : {m n p q : ℕ}
-                          → (T : m ⊸ n) → (B : p ⊸ q)
+                          → (T : m ⊸ n) (B : p ⊸ q)
                           → (u v : Vec A (m +ᴺ p))
                           → T ·ˡᵐ (take m (u +ⱽ v)) ++ B ·ˡᵐ (drop m (u +ⱽ v)) ≡
                              (T ·ˡᵐ (take m u) ++ B ·ˡᵐ (drop m u)) +ⱽ
@@ -234,7 +233,7 @@ module _ ⦃ F : Field A ⦄ where
           ∎
 
         f[c*v]≡c*f[v]' : {m n p q : ℕ}
-                       → (T : m ⊸ n) → (B : p ⊸ q)
+                       → (T : m ⊸ n) (B : p ⊸ q)
                        → (c : A) (v : Vec A (m +ᴺ p))
                        → T ·ˡᵐ (take m (c *ᶜ v)) ++ B ·ˡᵐ (drop m (c *ᶜ v)) ≡
                           c *ᶜ (T ·ˡᵐ (take m v) ++ B ·ˡᵐ (drop m v))

--- a/src/FLA/Algebra/LinearMap.agda
+++ b/src/FLA/Algebra/LinearMap.agda
@@ -29,7 +29,8 @@ private
     A : Set ℓ
     m n p q : ℕ
 
-record LinearMap (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
+-- A linear map from one vector field to another
+record _⊸_ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
   field
     f : (Vec A m → Vec A n)
 
@@ -39,21 +40,28 @@ record LinearMap (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
     -- Homogeneity
     f[c*v]≡c*f[v] : (c : A) → (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v)
 
+infixr 1 _⊸_
+
+-- A convenient syntax if a particular set needs to be specified.
+_—_⊸_ : {ℓ : Level} (m : ℕ) (A : Set ℓ) (n : ℕ) ⦃ F : Field A ⦄ → Set ℓ
+m — A ⊸ n  = _⊸_ {A = A} m n
+infixr 1 _—_⊸_
+
 module _ ⦃ F : Field A ⦄ where
   open Field F
-  open LinearMap
+  open _⊸_
 
-  _·ˡᵐ_ : LinearMap A m n → Vec A m → Vec A n
+  _·ˡᵐ_ : m ⊸ n → Vec A m → Vec A n
   _·ˡᵐ_ LM = f LM
 
-  _+ˡᵐ_ : LinearMap A m n → LinearMap A m n → LinearMap A m n
+  _+ˡᵐ_ : m ⊸ n → m ⊸ n → m ⊸ n
   g +ˡᵐ h = record
     { f = λ v → g ·ˡᵐ v +ⱽ h ·ˡᵐ v
     ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]' g h
     ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]' g h
     }
     where
-      f[u+v]≡f[u]+f[v]' : (g h : LinearMap A m n) → (u v : Vec A m)
+      f[u+v]≡f[u]+f[v]' : (g h : m ⊸ n) → (u v : Vec A m)
                         → g ·ˡᵐ (u +ⱽ v) +ⱽ h ·ˡᵐ (u +ⱽ v) ≡
                            g ·ˡᵐ u +ⱽ h ·ˡᵐ u +ⱽ (g ·ˡᵐ v +ⱽ h ·ˡᵐ v)
       f[u+v]≡f[u]+f[v]' g h u v rewrite
@@ -66,7 +74,7 @@ module _ ⦃ F : Field A ⦄ where
         | sym (+ⱽ-assoc (g ·ˡᵐ u) (h ·ˡᵐ u) (g ·ˡᵐ v +ⱽ h ·ˡᵐ v))
         = refl
   
-      f[c*v]≡c*f[v]' : (g h : LinearMap A m n) → (c : A) (v : Vec A m)
+      f[c*v]≡c*f[v]' : (g h : m ⊸ n) → (c : A) (v : Vec A m)
                      → g ·ˡᵐ (c *ᶜ v) +ⱽ h ·ˡᵐ (c *ᶜ v) ≡
                         c *ᶜ (g ·ˡᵐ v +ⱽ h ·ˡᵐ v)
       f[c*v]≡c*f[v]' g h c v rewrite
@@ -75,15 +83,15 @@ module _ ⦃ F : Field A ⦄ where
         | sym (*ᶜ-distr-+ⱽ c (g ·ˡᵐ v) (h ·ˡᵐ v))
         = refl
 
-  _*ˡᵐ_ : LinearMap A n p → LinearMap A m n → LinearMap A m p
+  _*ˡᵐ_ : n ⊸ p → m ⊸ n → m ⊸ p
   g *ˡᵐ h = record
     { f = λ v → g ·ˡᵐ (h ·ˡᵐ v)
     ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]' g h
     ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]' g h
     }
     where
-      f[u+v]≡f[u]+f[v]' : (g : LinearMap A n p)
-                        → (h : LinearMap A m n)
+      f[u+v]≡f[u]+f[v]' : (g : n ⊸ p)
+                        → (h : m ⊸ n)
                         → (u v : Vec A m)
                         → g ·ˡᵐ (h ·ˡᵐ (u +ⱽ v)) ≡ g ·ˡᵐ (h ·ˡᵐ u) +ⱽ g ·ˡᵐ (h ·ˡᵐ v)
       f[u+v]≡f[u]+f[v]' g h u v rewrite
@@ -91,8 +99,8 @@ module _ ⦃ F : Field A ⦄ where
         | f[u+v]≡f[u]+f[v] g (f h u) (f h v)
         = refl
   
-      f[c*v]≡c*f[v]' : (g : LinearMap A n p)
-                     → (h : LinearMap A m n)
+      f[c*v]≡c*f[v]' : (g : n ⊸ p)
+                     → (h : m ⊸ n)
                      → (c : A) (v : Vec A m)
                      → g ·ˡᵐ (h ·ˡᵐ (c *ᶜ v)) ≡ c *ᶜ g ·ˡᵐ (h ·ˡᵐ v)
       f[c*v]≡c*f[v]' g h c v rewrite
@@ -101,7 +109,7 @@ module _ ⦃ F : Field A ⦄ where
         = refl
 
   -- vertical stack forward operator
-  _—ˡᵐ_ : LinearMap A p m → LinearMap A p n → LinearMap A p (m +ᴺ n)
+  _—ˡᵐ_ : p ⊸ m → p ⊸ n → p ⊸ (m +ᴺ n)
   T —ˡᵐ B =
     record
       { f = λ v →  T ·ˡᵐ v ++ B ·ˡᵐ v
@@ -109,7 +117,7 @@ module _ ⦃ F : Field A ⦄ where
       ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]' T B
       }
     where
-      f[u+v]≡f[u]+f[v]' : (T : LinearMap A p m) → (B : LinearMap A p n)
+      f[u+v]≡f[u]+f[v]' : (T : p ⊸ m) → (B : p ⊸ n)
                         → (u v : Vec A p)
                         → T ·ˡᵐ (u +ⱽ v) ++ B ·ˡᵐ (u +ⱽ v) ≡
                           (T ·ˡᵐ u ++ B ·ˡᵐ u) +ⱽ (T ·ˡᵐ v ++ B ·ˡᵐ v)
@@ -119,7 +127,7 @@ module _ ⦃ F : Field A ⦄ where
         | +ⱽ-flip-++ (T ·ˡᵐ u) (T ·ˡᵐ v) (B ·ˡᵐ u) (B ·ˡᵐ v)
         = refl
 
-      f[c*v]≡c*f[v]' : (T : LinearMap A p m) → (B : LinearMap A p n)
+      f[c*v]≡c*f[v]' : (T : p ⊸ m) → (B : p ⊸ n)
                      → (c : A) → (v : Vec A p)
                      → T ·ˡᵐ (c *ᶜ v) ++ B ·ˡᵐ (c *ᶜ v) ≡
                         c *ᶜ (T ·ˡᵐ v ++ B ·ˡᵐ v)
@@ -130,7 +138,7 @@ module _ ⦃ F : Field A ⦄ where
         = refl
 
   -- horizontal stack forward operator
-  _|ˡᵐ_ : LinearMap A m p → LinearMap A n p → LinearMap A (m +ᴺ n) p
+  _|ˡᵐ_ : m ⊸ p → n ⊸ p → (m +ᴺ n) ⊸ p
   _|ˡᵐ_ {m} {n} {p} T B =
     record
       { f = λ v → T ·ˡᵐ (take m v) +ⱽ B ·ˡᵐ (drop m v)
@@ -139,7 +147,7 @@ module _ ⦃ F : Field A ⦄ where
       }
       where
         f[u+v]≡f[u]+f[v]' : {m n p : ℕ}
-                          → (T : LinearMap A m p) → (B : LinearMap A n p)
+                          → (T : m ⊸ p) → (B : n ⊸ p)
                           → (u v : Vec A (m +ᴺ n))
                           → T ·ˡᵐ take m (u +ⱽ v) +ⱽ B ·ˡᵐ drop m (u +ⱽ v) ≡
                              T ·ˡᵐ take m u +ⱽ B ·ˡᵐ drop m u +ⱽ
@@ -178,7 +186,7 @@ module _ ⦃ F : Field A ⦄ where
           ∎
 
         f[c*v]≡c*f[v]' : {m n p : ℕ}
-                       → (T : LinearMap A m p) → (B : LinearMap A n p)
+                       → (T : m ⊸ p) → (B : n ⊸ p)
                        → (c : A) (v : Vec A (m +ᴺ n))
                        → T ·ˡᵐ take m (c *ᶜ v) +ⱽ B ·ˡᵐ drop m (c *ᶜ v) ≡
                           c *ᶜ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
@@ -195,7 +203,7 @@ module _ ⦃ F : Field A ⦄ where
           ∎
 
   -- block diagonal forward and adjoint operator
-  _/ˡᵐ_ : LinearMap A m n → LinearMap A p q → LinearMap A (m +ᴺ p) (n +ᴺ q)
+  _/ˡᵐ_ : m ⊸ n → p ⊸ q → (m +ᴺ p) ⊸ (n +ᴺ q)
   _/ˡᵐ_ {m} {n} {p} {q} T B =
     record
       { f = λ v → T ·ˡᵐ (take m v) ++ B ·ˡᵐ (drop m v)
@@ -204,7 +212,7 @@ module _ ⦃ F : Field A ⦄ where
       }
       where
         f[u+v]≡f[u]+f[v]' : {m n p q : ℕ}
-                          → (T : LinearMap A m n) → (B : LinearMap A p q)
+                          → (T : m ⊸ n) → (B : p ⊸ q)
                           → (u v : Vec A (m +ᴺ p))
                           → T ·ˡᵐ (take m (u +ⱽ v)) ++ B ·ˡᵐ (drop m (u +ⱽ v)) ≡
                              (T ·ˡᵐ (take m u) ++ B ·ˡᵐ (drop m u)) +ⱽ
@@ -226,7 +234,7 @@ module _ ⦃ F : Field A ⦄ where
           ∎
 
         f[c*v]≡c*f[v]' : {m n p q : ℕ}
-                       → (T : LinearMap A m n) → (B : LinearMap A p q)
+                       → (T : m ⊸ n) → (B : p ⊸ q)
                        → (c : A) (v : Vec A (m +ᴺ p))
                        → T ·ˡᵐ (take m (c *ᶜ v)) ++ B ·ˡᵐ (drop m (c *ᶜ v)) ≡
                           c *ᶜ (T ·ˡᵐ (take m v) ++ B ·ˡᵐ (drop m v))
@@ -255,14 +263,14 @@ module _ ⦃ F : Field A ⦄ where
 
 -- Example LinearMap values ---------------------------------------------------
 
-idₗₘ : ⦃ F : Field A ⦄ → LinearMap A n n
+idₗₘ : ⦃ F : Field A ⦄ → n ⊸ n
 idₗₘ = record
   { f = id
   ; f[u+v]≡f[u]+f[v] = λ u v → refl
   ; f[c*v]≡c*f[v] = λ c v → refl
   }
 
-diagₗₘ : ⦃ F : Field A ⦄ → Vec A n → LinearMap A n n
+diagₗₘ : ⦃ F : Field A ⦄ → Vec A n → n ⊸ n
 diagₗₘ d = record
   { f = d ∘ⱽ_
   ; f[u+v]≡f[u]+f[v] = ∘ⱽ-distr-+ⱽ d


### PR DESCRIPTION
⊸ is not the linear logic implication but is meant to imply the linearity property.