### PR TITLE
Clean up imports, rename *ᶜ to ∘ⱽ, ∘ⱽ to *ⱽ, M_∶_×_ to Mat_×_

### DIFF
--- a/src/FLA/Algebra/LinearAlgebra.agda
+++ b/src/FLA/Algebra/LinearAlgebra.agda
@@ -2,10 +2,10 @@
 
 open import Level using (Level)
 
-open import Relation.Binary.PropositionalEquality hiding (∀-extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
-open import Data.Nat using (ℕ; suc; zero)
+open import Data.Nat using (ℕ)
 open import Data.Vec using (Vec; foldr; zipWith; map)
 
 open import FLA.Algebra.Structures
@@ -19,7 +19,6 @@ private
     A : Set ℓ
     m n p q : ℕ
 
-
 module _ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ where
   open Field F
 
@@ -28,21 +27,21 @@ module _ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ where
   _+ⱽ_ = zipWith _+_
 
   -- Vector Hadamard product
-  _∘ⱽ_ : ⦃ F : Field A ⦄ → Vec A n → Vec A n → Vec A n
-  _∘ⱽ_ = zipWith _*_
+  _*ⱽ_ : ⦃ F : Field A ⦄ → Vec A n → Vec A n → Vec A n
+  _*ⱽ_ = zipWith _*_
 
   -- Multiply vector by a constant
-  _*ᶜ_ : ⦃ F : Field A ⦄ → A → Vec A n → Vec A n
-  c *ᶜ v = map (c *_) v
+  _∘ⱽ_ : ⦃ F : Field A ⦄ → A → Vec A n → Vec A n
+  c ∘ⱽ v = map (c *_) v
 
   -- Match the fixity of Haskell
   infixl  6 _+ⱽ_
-  infixl  7 _∘ⱽ_
-  infixl 10 _*ᶜ_
+  infixl  7 _*ⱽ_
+  infixl 10 _∘ⱽ_
 
   sum : Vec A n → A
   sum = foldr _ _+_ 0ᶠ
 
--- Inner product
-⟨_,_⟩ : ⦃ F : Field A ⦄ → Vec A n → Vec A n → A
-⟨ v₁ , v₂ ⟩ = sum (v₁ ∘ⱽ v₂)
+  -- Inner product
+  ⟨_,_⟩ : Vec A n → Vec A n → A
+  ⟨ v₁ , v₂ ⟩ = sum (v₁ *ⱽ v₂)

--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -30,22 +30,22 @@ private
 --                          M constructor and values                         --
 -------------------------------------------------------------------------------
 
-data M_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
+data Mat_×_ {A : Set ℓ} ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
   ⟦_,_,_⟧ : (M : n ⊸ m )
           → (Mᵀ : m ⊸ n )
           → (p : (x : Vec A m) → (y : Vec A n)
                → ⟨ x , M ·ˡᵐ y ⟩ ≡ ⟨ y , Mᵀ ·ˡᵐ x ⟩ )
-          → M A ∶ m × n
+          → Mat m × n
 
-module _ where
+module _ ⦃ F : Field A ⦄ where
 
-  _ᵀ : ⦃ F : Field A ⦄ → M A ∶ m × n → M A ∶ n × m
+  _ᵀ : Mat m × n → Mat n × m
   ⟦ f , a , p ⟧ ᵀ = ⟦ a , f , (λ x y → sym (p y x)) ⟧
 
-  _·ᴹₗ_ : ⦃ F : Field A ⦄ → M A ∶ m × n → Vec A n → Vec A m
+  _·ᴹₗ_ : Mat m × n → Vec A n → Vec A m
   ⟦ f , _ , _ ⟧ ·ᴹₗ x = f ·ˡᵐ x
 
-  _·ᴹᵣ_ : ⦃ F : Field A ⦄ → Vec A m → M A ∶ m × n → Vec A n
+  _·ᴹᵣ_ : Vec A m → Mat m × n → Vec A n
   x ·ᴹᵣ ⟦ _ , a , _ ⟧ = a ·ˡᵐ x
 
   infixr 20 _·ᴹᵣ_
@@ -57,7 +57,7 @@ module _ ⦃ F : Field A ⦄ where
   open Field F
   open _⊸_
 
-  _+ᴹ_ : M A ∶ m × n → M A ∶ m × n → M A ∶ m × n
+  _+ᴹ_ : Mat m × n → Mat m × n → Mat m × n
   ⟦ M₁ , M₁ᵀ , p₁ ⟧ +ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
     ⟦ M₁ +ˡᵐ M₂
     , M₁ᵀ +ˡᵐ M₂ᵀ
@@ -86,7 +86,7 @@ module _ ⦃ F : Field A ⦄ where
             ⟨ y , (M₁ᵀ +ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
         ∎
 
-  _*ᴹ_ : M A ∶ m × n → M A ∶ n × p → M A ∶ m × p
+  _*ᴹ_ : Mat m × n → Mat n × p → Mat m × p
   ⟦ M₁ , M₁ᵀ , p₁ ⟧ *ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
     ⟦ M₁ *ˡᵐ M₂
     , M₂ᵀ *ˡᵐ M₁ᵀ
@@ -108,7 +108,7 @@ module _ ⦃ F : Field A ⦄ where
           ⟨ M₁ᵀ ·ˡᵐ x , M₂ ·ˡᵐ y ⟩    ≡⟨ M₂-proof (M₁ᵀ ·ˡᵐ x) y ⟩
           ⟨ y , (M₂ᵀ *ˡᵐ M₁ᵀ) ·ˡᵐ x ⟩ ∎
 
-  _|ᴹ_ : M A ∶ m × n → M A ∶ m × p → M A ∶ m × (n +ᴺ p)
+  _|ᴹ_ : Mat m × n → Mat m × p → Mat m × (n +ᴺ p)
   ⟦ M₁ , M₁ᵀ , p₁ ⟧ |ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
     ⟦ M₁ |ˡᵐ M₂
     , M₁ᵀ —ˡᵐ M₂ᵀ
@@ -141,11 +141,11 @@ module _ ⦃ F : Field A ⦄ where
             ⟨ y , (M₁ᵀ —ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
         ∎
 
-  _—ᴹ_ : M A ∶ m × p → M A ∶ n × p → M A ∶ (m +ᴺ n) × p
+  _—ᴹ_ : Mat m × p → Mat n × p → Mat (m +ᴺ n) × p
   M —ᴹ N = (M ᵀ |ᴹ N ᵀ) ᵀ
 
   -- Block diagonal matrix
-  _/ᴹ_ : M A ∶ m × n → M A ∶ p × q → M A ∶ (m +ᴺ p) × (n +ᴺ q)
+  _/ᴹ_ : Mat m × n → Mat p × q → Mat (m +ᴺ p) × (n +ᴺ q)
   ⟦ M₁ , M₁ᵀ , p₁ ⟧ /ᴹ ⟦ M₂ , M₂ᵀ , p₂ ⟧ =
     ⟦ M₁ /ˡᵐ M₂
     , M₁ᵀ /ˡᵐ M₂ᵀ
@@ -185,7 +185,7 @@ module _ ⦃ F : Field A ⦄ where
         ∎
 
   -- Multiply by a constant
-  _∘ᴹ_ : A → M A ∶ m × n → M A ∶ m × n
+  _∘ᴹ_ : A → Mat m × n → Mat m × n
   c ∘ᴹ ⟦ M , Mᵀ , p ⟧ = ⟦ c ∘ˡᵐ M , c ∘ˡᵐ Mᵀ , ⟨⟩-proof M Mᵀ c p ⟧
     where
       ⟨⟩-proof : {m n : ℕ} (M : n ⊸ m) (Mᵀ : m ⊸ n) (c : A)
@@ -224,7 +224,7 @@ module _ ⦃ F : Field A ⦄ where
 module _ ⦃ F : Field A ⦄ where
   open Field F
 
-  I : M A ∶ n × n
+  I : Mat n × n
   I = ⟦ idₗₘ , idₗₘ , id-transpose  ⟧
     where
       id-transpose : (x y : Vec A n)
@@ -233,7 +233,7 @@ module _ ⦃ F : Field A ⦄ where
           zipWith-comm (_*_) (*-comm) x y
         = refl
 
-  diag : Vec A n → M A ∶ n × n
+  diag : Vec A n → Mat n × n
   diag d = ⟦ diagₗₘ d , diagₗₘ d , diag-transpose d ⟧
     where
       diag-transpose : (d : Vec A n) → (x y : Vec A n)

--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -1,14 +1,11 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Level using (Level)
-open import Data.Nat using (ℕ; suc; zero) renaming (_+_ to _+ᴺ_)
+open import Data.Nat using (ℕ) renaming (_+_ to _+ᴺ_)
 
-open import Data.Empty
+open import Data.Vec using (Vec; _++_; take; drop)
 
-open import Data.Vec using (Vec; foldr; zipWith; map; _++_; take; drop)
-open import Data.Product hiding (map; _,_)
-
-open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
 open import Function using (id)
@@ -200,15 +197,15 @@ module _ ⦃ F : Field A ⦄ where
         begin
             ⟨ x , (c ∘ˡᵐ M) ·ˡᵐ y ⟩
           ≡⟨⟩
-            ⟨ x , c *ᶜ (M ·ˡᵐ y) ⟩
+            ⟨ x , c ∘ⱽ (M ·ˡᵐ y) ⟩
           ≡⟨ cong (λ z → ⟨ x , z ⟩) (sym (f[c*v]≡c*f[v] M c y)) ⟩
-            ⟨ x , M ·ˡᵐ (c *ᶜ y) ⟩
-          ≡⟨ M-⟨⟩-proof x ((c *ᶜ y)) ⟩
-            ⟨ c *ᶜ y , Mᵀ ·ˡᵐ x ⟩
-          ≡⟨ ⟨⟩-comm (c *ᶜ y) (Mᵀ ·ˡᵐ x) ⟩
-            ⟨ Mᵀ ·ˡᵐ x , c *ᶜ y ⟩
-          ≡⟨ cong sum (trans (∘ⱽ*ᶜ≡*ᶜ∘ⱽ c (Mᵀ ·ˡᵐ x) y)
-                             (*ᶜ∘ⱽ-assoc c (Mᵀ ·ˡᵐ x) y)) ⟩
+            ⟨ x , M ·ˡᵐ (c ∘ⱽ y) ⟩
+          ≡⟨ M-⟨⟩-proof x ((c ∘ⱽ y)) ⟩
+            ⟨ c ∘ⱽ y , Mᵀ ·ˡᵐ x ⟩
+          ≡⟨ ⟨⟩-comm (c ∘ⱽ y) (Mᵀ ·ˡᵐ x) ⟩
+            ⟨ Mᵀ ·ˡᵐ x , c ∘ⱽ y ⟩
+          ≡⟨ cong sum (trans (*ⱽ∘ⱽ≡∘ⱽ*ⱽ c (Mᵀ ·ˡᵐ x) y)
+                             (∘ⱽ*ⱽ-assoc c (Mᵀ ·ˡᵐ x) y)) ⟩
             ⟨ (c ∘ˡᵐ Mᵀ) ·ˡᵐ x , y ⟩
           ≡⟨ ⟨⟩-comm ((c ∘ˡᵐ Mᵀ) ·ˡᵐ x) y ⟩
             ⟨ y , (c ∘ˡᵐ Mᵀ) ·ˡᵐ x ⟩
@@ -244,8 +241,8 @@ module _ ⦃ F : Field A ⦄ where
       diag-transpose d x y =
         begin
           ⟨ x , diagₗₘ d ·ˡᵐ y ⟩ ≡⟨⟩
-          sum (x ∘ⱽ (d ∘ⱽ y))    ≡⟨ cong (sum) (∘ⱽ-comm x (d ∘ⱽ y)) ⟩
-          sum ((d ∘ⱽ y) ∘ⱽ x)    ≡⟨ cong (λ dy → sum (dy ∘ⱽ x)) (∘ⱽ-comm d y) ⟩
-          sum ((y ∘ⱽ d) ∘ⱽ x)    ≡⟨ cong sum (∘ⱽ-assoc y d x) ⟩
-          sum (y ∘ⱽ (d ∘ⱽ x))    ≡⟨⟩
+          sum (x *ⱽ (d *ⱽ y))    ≡⟨ cong (sum) (*ⱽ-comm x (d *ⱽ y)) ⟩
+          sum ((d *ⱽ y) *ⱽ x)    ≡⟨ cong (λ dy → sum (dy *ⱽ x)) (*ⱽ-comm d y) ⟩
+          sum ((y *ⱽ d) *ⱽ x)    ≡⟨ cong sum (*ⱽ-assoc y d x) ⟩
+          sum (y *ⱽ (d *ⱽ x))    ≡⟨⟩
           ⟨ y , diagₗₘ d ·ˡᵐ x ⟩ ∎

--- a/src/FLA/Algebra/LinearAlgebra/Properties.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties.agda
@@ -2,16 +2,15 @@
 
 open import Level using (Level)
 
-open import Relation.Binary.PropositionalEquality hiding (∀-extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
-open import Data.Nat using (ℕ; suc; zero)
-open import Data.Vec using (Vec; foldr; zipWith; map; []; _∷_; _++_)
+open import Data.Nat using (ℕ)
+open import Data.Vec using (Vec; []; _∷_; foldr; _++_)
 
 open import FLA.Algebra.Structures
 open import FLA.Algebra.Properties.Field
 open import FLA.Algebra.LinearAlgebra
-open import FLA.Data.Vec.Properties
 
 module FLA.Algebra.LinearAlgebra.Properties where
 
@@ -40,74 +39,74 @@ module _ ⦃ F : Field A ⦄ where
       x₁ + x₂ ∷ vs₂ +ⱽ vs₁ ≡⟨ cong (_∷ vs₂ +ⱽ vs₁) (+-comm x₁ x₂) ⟩
       x₂ + x₁ ∷ vs₂ +ⱽ vs₁ ∎
 
-  ∘ⱽ-assoc : (v₁ v₂ v₃ : Vec A n)
-           → v₁ ∘ⱽ v₂ ∘ⱽ v₃ ≡ v₁ ∘ⱽ (v₂ ∘ⱽ v₃)
-  ∘ⱽ-assoc [] [] [] = refl
-  ∘ⱽ-assoc (v₁ ∷ vs₁) (v₂ ∷ vs₂) (v₃ ∷ vs₃) rewrite
-      ∘ⱽ-assoc vs₁ vs₂ vs₃
+  *ⱽ-assoc : (v₁ v₂ v₃ : Vec A n)
+           → v₁ *ⱽ v₂ *ⱽ v₃ ≡ v₁ *ⱽ (v₂ *ⱽ v₃)
+  *ⱽ-assoc [] [] [] = refl
+  *ⱽ-assoc (v₁ ∷ vs₁) (v₂ ∷ vs₂) (v₃ ∷ vs₃) rewrite
+      *ⱽ-assoc vs₁ vs₂ vs₃
     | *-assoc v₁ v₂ v₃
     = refl
 
-  ∘ⱽ-comm : (v₁ v₂ : Vec A n) → v₁ ∘ⱽ v₂ ≡ v₂ ∘ⱽ v₁
-  ∘ⱽ-comm [] [] = refl
-  ∘ⱽ-comm (v₁ ∷ vs₁) (v₂ ∷ vs₂) rewrite
-      ∘ⱽ-comm vs₁ vs₂
+  *ⱽ-comm : (v₁ v₂ : Vec A n) → v₁ *ⱽ v₂ ≡ v₂ *ⱽ v₁
+  *ⱽ-comm [] [] = refl
+  *ⱽ-comm (v₁ ∷ vs₁) (v₂ ∷ vs₂) rewrite
+      *ⱽ-comm vs₁ vs₂
     | *-comm v₁ v₂
     = refl
 
-  ∘ⱽ-distr-+ⱽ : (a u v : Vec A n)
-              → a ∘ⱽ (u +ⱽ v) ≡ a ∘ⱽ u +ⱽ a ∘ⱽ v
-  ∘ⱽ-distr-+ⱽ [] [] [] = refl
-  ∘ⱽ-distr-+ⱽ (a ∷ as) (u ∷ us) (v ∷ vs) rewrite
-      ∘ⱽ-distr-+ⱽ as us vs
+  *ⱽ-distr-+ⱽ : (a u v : Vec A n)
+              → a *ⱽ (u +ⱽ v) ≡ a *ⱽ u +ⱽ a *ⱽ v
+  *ⱽ-distr-+ⱽ [] [] [] = refl
+  *ⱽ-distr-+ⱽ (a ∷ as) (u ∷ us) (v ∷ vs) rewrite
+      *ⱽ-distr-+ⱽ as us vs
     | *-distr-+ a u v
     = refl
 
   -- Homogeneity of degree 1 for linear maps
-  ∘ⱽ*ᶜ≡*ᶜ∘ⱽ : (c : A) (u v : Vec A n)
-            → u ∘ⱽ c *ᶜ v ≡ c *ᶜ (u ∘ⱽ v)
-  ∘ⱽ*ᶜ≡*ᶜ∘ⱽ c [] [] = refl
-  ∘ⱽ*ᶜ≡*ᶜ∘ⱽ c (u ∷ us) (v ∷ vs) rewrite
-      ∘ⱽ*ᶜ≡*ᶜ∘ⱽ c us vs
+  *ⱽ∘ⱽ≡∘ⱽ*ⱽ : (c : A) (u v : Vec A n)
+            → u *ⱽ c ∘ⱽ v ≡ c ∘ⱽ (u *ⱽ v)
+  *ⱽ∘ⱽ≡∘ⱽ*ⱽ c [] [] = refl
+  *ⱽ∘ⱽ≡∘ⱽ*ⱽ c (u ∷ us) (v ∷ vs) rewrite
+      *ⱽ∘ⱽ≡∘ⱽ*ⱽ c us vs
     | *-assoc u c v
     | *-comm u c
     | sym (*-assoc c u v)
     = refl
 
-  *ᶜ∘ⱽ-assoc : (c : A) (u v : Vec A n)
-             → c *ᶜ (u ∘ⱽ v) ≡ (c *ᶜ u) ∘ⱽ v
-  *ᶜ∘ⱽ-assoc c [] [] = refl
-  *ᶜ∘ⱽ-assoc c (u ∷ us) (v ∷ vs) = cong₂ (_∷_) (*-assoc c u v)
-                                               (*ᶜ∘ⱽ-assoc c us vs)
+  ∘ⱽ*ⱽ-assoc : (c : A) (u v : Vec A n)
+             → c ∘ⱽ (u *ⱽ v) ≡ (c ∘ⱽ u) *ⱽ v
+  ∘ⱽ*ⱽ-assoc c [] [] = refl
+  ∘ⱽ*ⱽ-assoc c (u ∷ us) (v ∷ vs) = cong₂ (_∷_) (*-assoc c u v)
+                                               (∘ⱽ*ⱽ-assoc c us vs)
 
-  *ᶜ-distr-+ⱽ : (c : A) (u v : Vec A n)
-              → c *ᶜ (u +ⱽ v) ≡ c *ᶜ u +ⱽ c *ᶜ v
-  *ᶜ-distr-+ⱽ c [] [] = refl
-  *ᶜ-distr-+ⱽ c (u ∷ us) (v ∷ vs) rewrite
-      *ᶜ-distr-+ⱽ c us vs
+  ∘ⱽ-distr-+ⱽ : (c : A) (u v : Vec A n)
+              → c ∘ⱽ (u +ⱽ v) ≡ c ∘ⱽ u +ⱽ c ∘ⱽ v
+  ∘ⱽ-distr-+ⱽ c [] [] = refl
+  ∘ⱽ-distr-+ⱽ c (u ∷ us) (v ∷ vs) rewrite
+      ∘ⱽ-distr-+ⱽ c us vs
     | *-distr-+ c u v
     = refl
 
-  *ᶜ-comm : (a b : A) (v : Vec A n) → a *ᶜ (b *ᶜ v) ≡ b *ᶜ (a *ᶜ v)
-  *ᶜ-comm a b [] = refl
-  *ᶜ-comm a b (v ∷ vs) = cong₂ _∷_ (trans (trans (*-assoc a b v)
+  ∘ⱽ-comm : (a b : A) (v : Vec A n) → a ∘ⱽ (b ∘ⱽ v) ≡ b ∘ⱽ (a ∘ⱽ v)
+  ∘ⱽ-comm a b [] = refl
+  ∘ⱽ-comm a b (v ∷ vs) = cong₂ _∷_ (trans (trans (*-assoc a b v)
                                           (cong (_* v) (*-comm a b)))
                                           (sym (*-assoc b a v)))
-                                   (*ᶜ-comm a b vs)
+                                   (∘ⱽ-comm a b vs)
 
   +ⱽ-flip-++ : (a b : Vec A n) → (c d : Vec A m)
              → (a ++ c) +ⱽ (b ++ d) ≡ a +ⱽ b ++ c +ⱽ d
   +ⱽ-flip-++ [] [] c d = refl
   +ⱽ-flip-++ (a ∷ as) (b ∷ bs) c d rewrite +ⱽ-flip-++ as bs c d = refl
 
-  *ᶜ-distr-++ : (c : A) (a : Vec A n) (b : Vec A m)
-              → c *ᶜ (a ++ b) ≡ (c *ᶜ a) ++ (c *ᶜ b)
-  *ᶜ-distr-++ c [] b = refl
-  *ᶜ-distr-++ c (a ∷ as) b rewrite *ᶜ-distr-++ c as b = refl
+  ∘ⱽ-distr-++ : (c : A) (a : Vec A n) (b : Vec A m)
+              → c ∘ⱽ (a ++ b) ≡ (c ∘ⱽ a) ++ (c ∘ⱽ b)
+  ∘ⱽ-distr-++ c [] b = refl
+  ∘ⱽ-distr-++ c (a ∷ as) b rewrite ∘ⱽ-distr-++ c as b = refl
 
   ⟨⟩-comm : (v₁ v₂ : Vec A n)
           → ⟨ v₁ , v₂ ⟩ ≡ ⟨ v₂ , v₁ ⟩
-  ⟨⟩-comm v₁ v₂ = cong sum (∘ⱽ-comm v₁ v₂)
+  ⟨⟩-comm v₁ v₂ = cong sum (*ⱽ-comm v₁ v₂)
 
   sum-distr-+ⱽ : (v₁ v₂ : Vec A n) → sum (v₁ +ⱽ v₂) ≡ sum v₁ + sum v₂
   sum-distr-+ⱽ [] [] = sym (0ᶠ+0ᶠ≡0ᶠ)
@@ -129,13 +128,13 @@ module _ ⦃ F : Field A ⦄ where
   ⟨x+y,z⟩≡⟨x,z⟩+⟨y,z⟩ x y z = begin
     ⟨ x +ⱽ y , z ⟩
     ≡⟨⟩
-    sum ((x +ⱽ y) ∘ⱽ z )
-    ≡⟨ cong sum (∘ⱽ-comm (x +ⱽ y) z) ⟩
-    sum (z ∘ⱽ (x +ⱽ y))
-    ≡⟨ cong sum (∘ⱽ-distr-+ⱽ z x y) ⟩
-    sum (z ∘ⱽ x +ⱽ z ∘ⱽ y)
-    ≡⟨ sum-distr-+ⱽ (z ∘ⱽ x) (z ∘ⱽ y) ⟩
-    sum (z ∘ⱽ x) + sum (z ∘ⱽ y)
+    sum ((x +ⱽ y) *ⱽ z )
+    ≡⟨ cong sum (*ⱽ-comm (x +ⱽ y) z) ⟩
+    sum (z *ⱽ (x +ⱽ y))
+    ≡⟨ cong sum (*ⱽ-distr-+ⱽ z x y) ⟩
+    sum (z *ⱽ x +ⱽ z *ⱽ y)
+    ≡⟨ sum-distr-+ⱽ (z *ⱽ x) (z *ⱽ y) ⟩
+    sum (z *ⱽ x) + sum (z *ⱽ y)
     ≡⟨⟩
     ⟨ z , x ⟩ + ⟨ z , y ⟩
     ≡⟨ cong (_+ ⟨ z , y ⟩) (⟨⟩-comm z x) ⟩

--- a/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
@@ -27,32 +27,33 @@ private
     m n p q : ℕ
     ⦃ F ⦄ : Field A
 
+
 -------------------------------------------------------------------------------
---                   M without the inner product proof: M↓                   --
+--                   M without the inner product proof: Mat↓                   --
 -------------------------------------------------------------------------------
 
 private
-  data M↓_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
-    ⟦_,_⟧ : (M : n ⊸ m ) → (Mᵀ : m ⊸ n ) → M↓ A ∶ m × n
+  data Mat↓_∶_×_ (A : Set ℓ) ⦃ F : Field A ⦄ (m n : ℕ) : Set ℓ where
+    ⟦_,_⟧ : (M : n ⊸ m ) → (Mᵀ : m ⊸ n ) → Mat↓ A ∶ m × n
 
-  _·↓_ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → Vec A n → Vec A m
+  _·↓_ : ⦃ F : Field A ⦄ → Mat↓ A ∶ m × n → Vec A n → Vec A m
   ⟦ f , a ⟧ ·↓ x = f ·ˡᵐ x
 
-  _ᵀ↓ : ⦃ F : Field A ⦄ → M↓ A ∶ m × n → M↓ A ∶ n × m
+  _ᵀ↓ : ⦃ F : Field A ⦄ → Mat↓ A ∶ m × n → Mat↓ A ∶ n × m
   ⟦ f , a ⟧ ᵀ↓ = ⟦ a , f ⟧
 
   infixr 20 _·↓_
   infixl 25 _ᵀ↓
 
-  M→M↓ : ⦃ F : Field A ⦄ → M A ∶ m × n → M↓ A ∶ m × n
-  M→M↓ ⟦ M , Mᵀ , p ⟧ = ⟦ M , Mᵀ ⟧
+  Mat→Mat↓ : ⦃ F : Field A ⦄ → Mat m × n → Mat↓ A ∶ m × n
+  Mat→Mat↓ ⟦ M , Mᵀ , p ⟧ = ⟦ M , Mᵀ ⟧
 
-  M↓→M : ⦃ F : Field A ⦄
-        → (M↓ : M↓ A ∶ m × n)
+  Mat↓→Mat : ⦃ F : Field A ⦄
+        → (Mat↓ : Mat↓ A ∶ m × n)
         → (p : (x : Vec A m) → (y : Vec A n)
-              → ⟨ x , M↓ ·↓ y ⟩ ≡ ⟨ y , M↓ ᵀ↓ ·↓ x ⟩ )
-        → M A ∶ m × n
-  M↓→M ⟦ M , Mᵀ ⟧ p = ⟦ M , Mᵀ , p ⟧
+              → ⟨ x , Mat↓ ·↓ y ⟩ ≡ ⟨ y , Mat↓ ᵀ↓ ·↓ x ⟩ )
+        → Mat m × n
+  Mat↓→Mat ⟦ M , Mᵀ ⟧ p = ⟦ M , Mᵀ , p ⟧
 
   ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP : {ℓ : Level} → {A : Set ℓ} → ⦃ F : Field A ⦄
                     → (C : n ⊸ m) → (Cᵀ : m ⊸ n)
@@ -71,8 +72,8 @@ private
             → (x : Vec A m) →  (y : Vec A n) → p x y ≡ q x y
       f C Cᵀ p q (x) (y) = uip (p x y) (q x y)
 
-  M↓≡→M≡ : ⦃ F : Field A ⦄ → (C D : M A ∶ m × n) → (M→M↓ C ≡ M→M↓ D) → C ≡ D
-  M↓≡→M≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
+  Mat↓≡→Mat≡ : ⦃ F : Field A ⦄ → (C D : Mat m × n) → (Mat→Mat↓ C ≡ Mat→Mat↓ D) → C ≡ D
+  Mat↓≡→Mat≡ ⟦ C , Cᵀ , p ⟧ ⟦ .C , .Cᵀ , q ⟧ refl rewrite
     ⟨x,Ay⟩≡⟨y,Aᵀx⟩-UIP C Cᵀ p q = refl
 
 
@@ -83,46 +84,46 @@ private
 module _ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ where
   open Field F
 
-  ᵀᵀ : (B : M A ∶ m × n) → B ᵀ ᵀ ≡ B
-  ᵀᵀ B = M↓≡→M≡ (B ᵀ ᵀ) B (ᵀᵀ↓ B)
+  ᵀᵀ : (B : Mat m × n) → B ᵀ ᵀ ≡ B
+  ᵀᵀ B = Mat↓≡→Mat≡ (B ᵀ ᵀ) B (ᵀᵀ↓ B)
     where
-      ᵀᵀ↓ : (B : M A ∶ m × n) → M→M↓ (B ᵀ ᵀ) ≡ M→M↓ B
+      ᵀᵀ↓ : (B : Mat m × n) → Mat→Mat↓ (B ᵀ ᵀ) ≡ Mat→Mat↓ B
       ᵀᵀ↓ ⟦ M , Mᵀ , p ⟧ = refl
 
-  ᵀ-distr-* : (L : M A ∶ m × n) (R : M A ∶ n × p)
+  ᵀ-distr-* : (L : Mat m × n) (R : Mat n × p)
             → (L *ᴹ R) ᵀ ≡ (R ᵀ *ᴹ L ᵀ)
-  ᵀ-distr-* L R = M↓≡→M≡ ((L *ᴹ R) ᵀ) (R ᵀ *ᴹ L ᵀ) (ᵀ-distr-*↓ L R)
+  ᵀ-distr-* L R = Mat↓≡→Mat≡ ((L *ᴹ R) ᵀ) (R ᵀ *ᴹ L ᵀ) (ᵀ-distr-*↓ L R)
     where
-      ᵀ-distr-*↓ : (L : M A ∶ m × n) (R : M A ∶ n × p)
-                → M→M↓ ((L *ᴹ R) ᵀ) ≡ M→M↓ (R ᵀ *ᴹ L ᵀ)
+      ᵀ-distr-*↓ : (L : Mat m × n) (R : Mat n × p)
+                → Mat→Mat↓ ((L *ᴹ R) ᵀ) ≡ Mat→Mat↓ (R ᵀ *ᴹ L ᵀ)
       ᵀ-distr-*↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ₁ , q ⟧ = refl
 
-  ᵀ-distr-+ : (L R : M A ∶ m × n) → (L +ᴹ R) ᵀ ≡ L ᵀ +ᴹ R ᵀ
-  ᵀ-distr-+ L R = M↓≡→M≡ ((L +ᴹ R) ᵀ) (L ᵀ +ᴹ R ᵀ) (ᵀ-distr-+↓ L R)
+  ᵀ-distr-+ : (L R : Mat m × n) → (L +ᴹ R) ᵀ ≡ L ᵀ +ᴹ R ᵀ
+  ᵀ-distr-+ L R = Mat↓≡→Mat≡ ((L +ᴹ R) ᵀ) (L ᵀ +ᴹ R ᵀ) (ᵀ-distr-+↓ L R)
     where
-      ᵀ-distr-+↓ : (L R : M A ∶ m × n)
-                 → M→M↓ ((L +ᴹ R) ᵀ) ≡ M→M↓ (L ᵀ +ᴹ R ᵀ)
+      ᵀ-distr-+↓ : (L R : Mat m × n)
+                 → Mat→Mat↓ ((L +ᴹ R) ᵀ) ≡ Mat→Mat↓ (L ᵀ +ᴹ R ᵀ)
       ᵀ-distr-+↓ ⟦ L , Lᵀ , p ⟧ ⟦ R , Rᵀ , q ⟧ = refl
 
-  *ᴹ-distr-+ᴹₗ : (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
+  *ᴹ-distr-+ᴹₗ : (X : Mat m × n) (Y Z : Mat n × p)
                → X *ᴹ (Y +ᴹ Z) ≡ X *ᴹ Y +ᴹ X *ᴹ Z
-  *ᴹ-distr-+ᴹₗ X Y Z = M↓≡→M≡ (X *ᴹ (Y +ᴹ Z)) (X *ᴹ Y +ᴹ X *ᴹ Z)
+  *ᴹ-distr-+ᴹₗ X Y Z = Mat↓≡→Mat≡ (X *ᴹ (Y +ᴹ Z)) (X *ᴹ Y +ᴹ X *ᴹ Z)
                               (*ᴹ-distr-+ᴹ↓ₗ X Y Z)
     where
-      *ᴹ-distr-+ᴹ↓ₗ : (X : M A ∶ m × n) (Y Z : M A ∶ n × p)
-                    → M→M↓ (X *ᴹ (Y +ᴹ Z)) ≡ M→M↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
+      *ᴹ-distr-+ᴹ↓ₗ : (X : Mat m × n) (Y Z : Mat n × p)
+                    → Mat→Mat↓ (X *ᴹ (Y +ᴹ Z)) ≡ Mat→Mat↓ (X *ᴹ Y +ᴹ X *ᴹ Z)
       *ᴹ-distr-+ᴹ↓ₗ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
           *ˡᵐ-distr-+ˡᵐₗ X Y Z
         | *ˡᵐ-distr-+ˡᵐᵣ Yᵀ Zᵀ Xᵀ
         = refl
 
-  *ᴹ-distr-+ᴹᵣ : (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
+  *ᴹ-distr-+ᴹᵣ : (X Y : Mat m × n) (Z : Mat n × p)
                → (X +ᴹ Y) *ᴹ Z ≡ X *ᴹ Z +ᴹ Y *ᴹ Z
-  *ᴹ-distr-+ᴹᵣ X Y Z = M↓≡→M≡ ((X +ᴹ Y) *ᴹ Z) (X *ᴹ Z +ᴹ Y *ᴹ Z)
+  *ᴹ-distr-+ᴹᵣ X Y Z = Mat↓≡→Mat≡ ((X +ᴹ Y) *ᴹ Z) (X *ᴹ Z +ᴹ Y *ᴹ Z)
                               (*ᴹ-distr-+ᴹ↓ᵣ X Y Z)
     where
-      *ᴹ-distr-+ᴹ↓ᵣ : (X Y : M A ∶ m × n) (Z : M A ∶ n × p)
-                    → M→M↓ ((X +ᴹ Y) *ᴹ Z) ≡ M→M↓ (X *ᴹ Z +ᴹ Y *ᴹ Z)
+      *ᴹ-distr-+ᴹ↓ᵣ : (X Y : Mat m × n) (Z : Mat n × p)
+                    → Mat→Mat↓ ((X +ᴹ Y) *ᴹ Z) ≡ Mat→Mat↓ (X *ᴹ Z +ᴹ Y *ᴹ Z)
       *ᴹ-distr-+ᴹ↓ᵣ ⟦ X , Xᵀ , Xₚ ⟧ ⟦ Y , Yᵀ , Yₚ ⟧ ⟦ Z , Zᵀ , Zₚ ⟧ rewrite
           *ˡᵐ-distr-+ˡᵐᵣ X Y Z
         | *ˡᵐ-distr-+ˡᵐₗ Zᵀ Xᵀ Yᵀ

--- a/src/FLA/Algebra/LinearMap.agda
+++ b/src/FLA/Algebra/LinearMap.agda
@@ -7,10 +7,9 @@ open import Level using (Level)
 open import Relation.Binary.PropositionalEquality hiding (Extensionality)
 open ≡-Reasoning
 
-open import Data.Nat using (ℕ; suc; zero) renaming (_+_ to _+ᴺ_)
+open import Data.Nat using (ℕ) renaming (_+_ to _+ᴺ_)
 open import Data.Nat.Properties
-open import Data.Vec using (Vec; foldr; zipWith; map; _++_; []; _∷_; take; drop)
-open import Data.Vec.Properties
+open import Data.Vec using (Vec; _++_; take; drop)
 
 open import Function using (id)
 
@@ -18,7 +17,6 @@ open import FLA.Algebra.Structures
 open import FLA.Algebra.Properties.Field
 open import FLA.Algebra.LinearAlgebra
 open import FLA.Algebra.LinearAlgebra.Properties
-open import FLA.Data.VectorList using (split)
 open import FLA.Data.Vec.Properties
 
 module FLA.Algebra.LinearMap where
@@ -38,7 +36,7 @@ record _⊸_ {ℓ : Level} {A : Set ℓ} ⦃ F : Field A ⦄ (m n : ℕ) : Set �
     f[u+v]≡f[u]+f[v] : (u v : Vec A m) → f (u +ⱽ v) ≡ f u +ⱽ f v
 
     -- Homogeneity
-    f[c*v]≡c*f[v] : (c : A) → (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v)
+    f[c*v]≡c*f[v] : (c : A) → (v : Vec A m) → f (c ∘ⱽ v) ≡ c ∘ⱽ (f v)
 
 infixr 1 _⊸_
 
@@ -75,12 +73,12 @@ module _ ⦃ F : Field A ⦄ where
         = refl
   
       f[c*v]≡c*f[v]' : (g h : m ⊸ n) → (c : A) (v : Vec A m)
-                     → g ·ˡᵐ (c *ᶜ v) +ⱽ h ·ˡᵐ (c *ᶜ v) ≡
-                        c *ᶜ (g ·ˡᵐ v +ⱽ h ·ˡᵐ v)
+                     → g ·ˡᵐ (c ∘ⱽ v) +ⱽ h ·ˡᵐ (c ∘ⱽ v) ≡
+                        c ∘ⱽ (g ·ˡᵐ v +ⱽ h ·ˡᵐ v)
       f[c*v]≡c*f[v]' g h c v rewrite
           f[c*v]≡c*f[v] g c v
         | f[c*v]≡c*f[v] h c v
-        | sym (*ᶜ-distr-+ⱽ c (g ·ˡᵐ v) (h ·ˡᵐ v))
+        | sym (∘ⱽ-distr-+ⱽ c (g ·ˡᵐ v) (h ·ˡᵐ v))
         = refl
 
   _*ˡᵐ_ : n ⊸ p → m ⊸ n → m ⊸ p
@@ -101,7 +99,7 @@ module _ ⦃ F : Field A ⦄ where
   
       f[c*v]≡c*f[v]' : (g : n ⊸ p) (h : m ⊸ n)
                      → (c : A) (v : Vec A m)
-                     → g ·ˡᵐ (h ·ˡᵐ (c *ᶜ v)) ≡ c *ᶜ g ·ˡᵐ (h ·ˡᵐ v)
+                     → g ·ˡᵐ (h ·ˡᵐ (c ∘ⱽ v)) ≡ c ∘ⱽ g ·ˡᵐ (h ·ˡᵐ v)
       f[c*v]≡c*f[v]' g h c v rewrite
           f[c*v]≡c*f[v] h c v
         | f[c*v]≡c*f[v] g c (h ·ˡᵐ v)
@@ -128,12 +126,12 @@ module _ ⦃ F : Field A ⦄ where
 
       f[c*v]≡c*f[v]' : (T : p ⊸ m) (B : p ⊸ n)
                      → (c : A) → (v : Vec A p)
-                     → T ·ˡᵐ (c *ᶜ v) ++ B ·ˡᵐ (c *ᶜ v) ≡
-                        c *ᶜ (T ·ˡᵐ v ++ B ·ˡᵐ v)
+                     → T ·ˡᵐ (c ∘ⱽ v) ++ B ·ˡᵐ (c ∘ⱽ v) ≡
+                        c ∘ⱽ (T ·ˡᵐ v ++ B ·ˡᵐ v)
       f[c*v]≡c*f[v]' T B c v rewrite
           f[c*v]≡c*f[v] T c v
         | f[c*v]≡c*f[v] B c v
-        | *ᶜ-distr-++ c (T ·ˡᵐ v) (B ·ˡᵐ v)
+        | ∘ⱽ-distr-++ c (T ·ˡᵐ v) (B ·ˡᵐ v)
         = refl
 
   -- horizontal stack forward operator
@@ -187,18 +185,18 @@ module _ ⦃ F : Field A ⦄ where
         f[c*v]≡c*f[v]' : {m n p : ℕ}
                        → (T : m ⊸ p) → (B : n ⊸ p)
                        → (c : A) (v : Vec A (m +ᴺ n))
-                       → T ·ˡᵐ take m (c *ᶜ v) +ⱽ B ·ˡᵐ drop m (c *ᶜ v) ≡
-                          c *ᶜ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
+                       → T ·ˡᵐ take m (c ∘ⱽ v) +ⱽ B ·ˡᵐ drop m (c ∘ⱽ v) ≡
+                          c ∘ⱽ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
         f[c*v]≡c*f[v]' {m} T B c v = begin
-            T ·ˡᵐ take m (c *ᶜ v) +ⱽ B ·ˡᵐ drop m (c *ᶜ v)
+            T ·ˡᵐ take m (c ∘ⱽ v) +ⱽ B ·ˡᵐ drop m (c ∘ⱽ v)
           ≡⟨ cong₂ (λ x y → T ·ˡᵐ x +ⱽ B ·ˡᵐ y) (take-distr-map (c *_) m v)
                                                  (drop-distr-map (c *_) m v) ⟩
-            T ·ˡᵐ (c *ᶜ take m v) +ⱽ B ·ˡᵐ (c *ᶜ drop m v)
+            T ·ˡᵐ (c ∘ⱽ take m v) +ⱽ B ·ˡᵐ (c ∘ⱽ drop m v)
           ≡⟨ cong₂ _+ⱽ_ (f[c*v]≡c*f[v] T c (take m v))
                         (f[c*v]≡c*f[v] B c (drop m v)) ⟩
-            c *ᶜ (T ·ˡᵐ take m v) +ⱽ c *ᶜ (B ·ˡᵐ drop m v)
-          ≡⟨ sym (*ᶜ-distr-+ⱽ c (T ·ˡᵐ take m v) (B ·ˡᵐ drop m v)) ⟩
-            c *ᶜ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
+            c ∘ⱽ (T ·ˡᵐ take m v) +ⱽ c ∘ⱽ (B ·ˡᵐ drop m v)
+          ≡⟨ sym (∘ⱽ-distr-+ⱽ c (T ·ˡᵐ take m v) (B ·ˡᵐ drop m v)) ⟩
+            c ∘ⱽ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
           ∎
 
   -- block diagonal forward and adjoint operator
@@ -235,30 +233,30 @@ module _ ⦃ F : Field A ⦄ where
         f[c*v]≡c*f[v]' : {m n p q : ℕ}
                        → (T : m ⊸ n) (B : p ⊸ q)
                        → (c : A) (v : Vec A (m +ᴺ p))
-                       → T ·ˡᵐ (take m (c *ᶜ v)) ++ B ·ˡᵐ (drop m (c *ᶜ v)) ≡
-                          c *ᶜ (T ·ˡᵐ (take m v) ++ B ·ˡᵐ (drop m v))
+                       → T ·ˡᵐ (take m (c ∘ⱽ v)) ++ B ·ˡᵐ (drop m (c ∘ⱽ v)) ≡
+                          c ∘ⱽ (T ·ˡᵐ (take m v) ++ B ·ˡᵐ (drop m v))
         f[c*v]≡c*f[v]' {m} T B c v =
           begin
-              T ·ˡᵐ take m (c *ᶜ v) ++ B ·ˡᵐ drop m (c *ᶜ v)
+              T ·ˡᵐ take m (c ∘ⱽ v) ++ B ·ˡᵐ drop m (c ∘ⱽ v)
             ≡⟨ cong₂ (λ x y → T ·ˡᵐ x ++ B ·ˡᵐ y) (take-distr-map (c *_) m v)
                                                    (drop-distr-map (c *_) m v) ⟩
-              T ·ˡᵐ (c *ᶜ take m v) ++ B ·ˡᵐ (c *ᶜ (drop m v))
+              T ·ˡᵐ (c ∘ⱽ take m v) ++ B ·ˡᵐ (c ∘ⱽ (drop m v))
             ≡⟨ cong₂ _++_ (f[c*v]≡c*f[v] T c (take m v))
                           (f[c*v]≡c*f[v] B c (drop m v)) ⟩
-              c *ᶜ (T ·ˡᵐ take m v) ++ c *ᶜ (B ·ˡᵐ drop m v)
-            ≡⟨ sym (*ᶜ-distr-++ c (T ·ˡᵐ take m v) (B ·ˡᵐ drop m v)) ⟩
-              c *ᶜ (T ·ˡᵐ take m v ++ B ·ˡᵐ drop m v)
+              c ∘ⱽ (T ·ˡᵐ take m v) ++ c ∘ⱽ (B ·ˡᵐ drop m v)
+            ≡⟨ sym (∘ⱽ-distr-++ c (T ·ˡᵐ take m v) (B ·ˡᵐ drop m v)) ⟩
+              c ∘ⱽ (T ·ˡᵐ take m v ++ B ·ˡᵐ drop m v)
           ∎
 
   -- Multiply by a constant
   _∘ˡᵐ_ : A → n ⊸ m → n ⊸ m
   c ∘ˡᵐ m =
     record
-      { f = λ v → c *ᶜ m ·ˡᵐ v
-      ; f[u+v]≡f[u]+f[v] = λ u v → trans (cong (c *ᶜ_) (f[u+v]≡f[u]+f[v] m u v))
-                                         (*ᶜ-distr-+ⱽ c (m ·ˡᵐ u) (m ·ˡᵐ v))
-      ; f[c*v]≡c*f[v] = λ c₁ v → trans (cong (c *ᶜ_) (f[c*v]≡c*f[v] m c₁ v))
-                                       (*ᶜ-comm c c₁ (f m v))
+      { f = λ v → c ∘ⱽ m ·ˡᵐ v
+      ; f[u+v]≡f[u]+f[v] = λ u v → trans (cong (c ∘ⱽ_) (f[u+v]≡f[u]+f[v] m u v))
+                                         (∘ⱽ-distr-+ⱽ c (m ·ˡᵐ u) (m ·ˡᵐ v))
+      ; f[c*v]≡c*f[v] = λ c₁ v → trans (cong (c ∘ⱽ_) (f[c*v]≡c*f[v] m c₁ v))
+                                       (∘ⱽ-comm c c₁ (f m v))
       }
 
   -- Choose 20 since function application is assumed higher than almost anything
@@ -284,7 +282,7 @@ module _ ⦃ F : Field A ⦄ where
 
   diagₗₘ : Vec A n → n ⊸ n
   diagₗₘ d = record
-    { f = d ∘ⱽ_
-    ; f[u+v]≡f[u]+f[v] = ∘ⱽ-distr-+ⱽ d
-    ; f[c*v]≡c*f[v] = λ c v → ∘ⱽ*ᶜ≡*ᶜ∘ⱽ c d v
+    { f = d *ⱽ_
+    ; f[u+v]≡f[u]+f[v] = *ⱽ-distr-+ⱽ d
+    ; f[c*v]≡c*f[v] = λ c v → *ⱽ∘ⱽ≡∘ⱽ*ⱽ c d v
     }

--- a/src/FLA/Algebra/LinearMap/Properties.agda
+++ b/src/FLA/Algebra/LinearMap/Properties.agda
@@ -4,9 +4,8 @@ open import Level using (Level)
 
 open import Axiom.UniquenessOfIdentityProofs.WithK using (uip)
 
-open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
-
 
 open import Data.Nat using (ℕ)
 open import Data.Vec using (Vec)
@@ -48,7 +47,7 @@ private
         → (f[u+v]≡f[u]+f[v] : (u v : Vec A m)
                              → L↓ ·ˡᵐ↓ (u +ⱽ v) ≡ L↓ ·ˡᵐ↓ u +ⱽ L↓ ·ˡᵐ↓ v)
         → (f[c*v]≡c*f[v] : (c : A) → (v : Vec A m)
-                          → L↓ ·ˡᵐ↓ (c *ᶜ v) ≡ c *ᶜ (L↓ ·ˡᵐ↓ v))
+                          → L↓ ·ˡᵐ↓ (c ∘ⱽ v) ≡ c ∘ⱽ (L↓ ·ˡᵐ↓ v))
         → m ⊸ n
   L↓→L (LM↓ f) f[u+v]≡f[u]+f[v] f[c*v]≡c*f[v] =
     record
@@ -74,14 +73,14 @@ private
 
   f[c*v]≡c*f[v]-UIP : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
                     → (f : Vec A m → Vec A n)
-                    → (p q : (c : A) (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v))
+                    → (p q : (c : A) (v : Vec A m) → f (c ∘ⱽ v) ≡ c ∘ⱽ (f v))
                     → p ≡ q
   f[c*v]≡c*f[v]-UIP f p q =
     extensionality (λ c → extensionality (λ v → t f p q c v))
     where
       t : {ℓ : Level} {A : Set ℓ} {m n : ℕ} → ⦃ F : Field A ⦄
         → (f : Vec A m → Vec A n)
-        → (p q : (c : A) (v : Vec A m) → f (c *ᶜ v) ≡ c *ᶜ (f v))
+        → (p q : (c : A) (v : Vec A m) → f (c ∘ⱽ v) ≡ c ∘ⱽ (f v))
         → (c : A) (v : Vec A m) → p c v ≡ q c v
       t f p q c v = uip (p c v) (q c v)
 

--- a/src/FLA/Algebra/Properties/Field.agda
+++ b/src/FLA/Algebra/Properties/Field.agda
@@ -6,7 +6,7 @@ open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
 
 module FLA.Algebra.Properties.Field {ℓ : Level } {A : Set ℓ} ⦃ F : Field A ⦄ where
 
-open Field {{...}}
+open Field F
 
 0ᶠ+0ᶠ≡0ᶠ : 0ᶠ + 0ᶠ ≡ 0ᶠ
 0ᶠ+0ᶠ≡0ᶠ = +-0 0ᶠ

--- a/src/FLA/Algebra/Structures.agda
+++ b/src/FLA/Algebra/Structures.agda
@@ -6,6 +6,7 @@
 module FLA.Algebra.Structures where
 
 open import Level using (Level) renaming (suc to lsuc)
+open import Data.Sum using (_⊎_)
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
 
 private
@@ -47,8 +48,7 @@ record LinearlyOrdered (A : Set ℓ) : Set (lsuc ℓ) where
   field
     _≤_ : A → A → Set ℓ
 
-    -- TODO: find the standard library way to represent a sum
-    -- total : x ≤ y or y ≤ x
+    total : (x y : A) → x ≤ y ⊎ y ≤ x
     trans : (x y z : A) → x ≤ y → y ≤ z → x ≤ z
     anti-sym : (x y : A) → x ≤ y → y ≤ x → x ≡ y
 


### PR DESCRIPTION
This way the multiplication symbol for vectors and matrices always
matches, with * being multiplication between two items of the same type
and ∘ being multiplication by a constant.