### PR TITLE
Use derivation from nixpkgs instead of redefining

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,8 @@
-# This package can be called with the nixpkg function
-# `agdaPackages.callPackage`, which is where the `standard-library` input comes
-# from.
-{ lib, stdenv, mkDerivation, standard-library }:
+# Since this package is already in nixpkgs, we just override the src.
+{ pkgs }:
 
-mkDerivation {
-  version = "0.1";
-  pname = "functional-linear-algebra";
-
-  buildInputs = [ standard-library ];
-
-  src = lib.sourceFilesBySuffices ./. [
+pkgs.agdaPackages.functional-linear-algebra.overrideAttrs (oldAttrs: rec {
+  src = pkgs.lib.sourceFilesBySuffices ./. [
     ".agda"
     ".lagda"
     ".lagda.md"
@@ -17,15 +10,4 @@ mkDerivation {
     ".lagda.tex"
     ".agda-lib"
   ];
-
-  meta = with stdenv.lib; {
-    homepage = "https://github.com/ryanorendorff/functional-linear-algebra";
-    description = ''
-      Formalizing linear algebra in Agda by representing matrices as functions
-      from one vector space to another.
-    '';
-    license = licenses.bsd3;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ ryanorendorff ];
-  };
-}
+})

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,3 +1,4 @@
+# nixpkgs unstable channel from October 15th, 2020
 import (builtins.fetchTarball {
   url =
     "https://github.com/NixOS/nixpkgs/archive/dfd0a64c1a25150092e1e6200fdc59da309466e5.tar.gz";

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,6 @@
+import (builtins.fetchTarball {
+  url =
+    "https://github.com/NixOS/nixpkgs/archive/dfd0a64c1a25150092e1e6200fdc59da309466e5.tar.gz";
+  sha256 = "1aadmhqd4d02kp7gk5r83r0p8d6n9qj1w7xlh0argi09msvamjcw";
+}) { }
+

--- a/release.nix
+++ b/release.nix
@@ -1,5 +1,1 @@
-let
-
-  # nixpkgs unstable channel from Aug 10 2020, 11:11 AM GMT
-  pkgs = import ./nixpkgs.nix;
-in import ./default.nix { inherit pkgs; }
+let pkgs = import ./nixpkgs.nix; in import ./default.nix { inherit pkgs; }

--- a/release.nix
+++ b/release.nix
@@ -1,10 +1,5 @@
 let
 
   # nixpkgs unstable channel from Aug 10 2020, 11:11 AM GMT
-  pkgs = import (builtins.fetchTarball {
-    url =
-      "https://github.com/NixOS/nixpkgs-channels/archive/32b46dd897ab2143a609988a04d87452f0bbef59.tar.gz";
-    sha256 = "1gzfrpjnr1bz9zljsyg3a4zrhk8r927sz761mrgcg56dwinkhpjk";
-  }) { };
-
-in pkgs.agdaPackages.callPackage ./default.nix { }
+  pkgs = import ./nixpkgs.nix;
+in import ./default.nix { inherit pkgs; }


### PR DESCRIPTION
Since the derivation is already specified in nixpkgs, we simply override
the source to be the local source.