### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,6 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v10
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v12
     - run: nix-build release.nix


### PR DESCRIPTION
The older install nix action used a now deprecated feature that was a security concern, so github actions would fail. This should fix that problem.