### PR TITLE
Update to use agda-stdlib 1.4

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,7 @@
-# nixpkgs unstable channel from October 15th, 2020
+# nixpkgs unstable channel from November 25th, 2020
 import (builtins.fetchTarball {
   url =
-    "https://github.com/NixOS/nixpkgs/archive/dfd0a64c1a25150092e1e6200fdc59da309466e5.tar.gz";
-  sha256 = "1aadmhqd4d02kp7gk5r83r0p8d6n9qj1w7xlh0argi09msvamjcw";
+    "https://github.com/NixOS/nixpkgs/archive/d47eb666b1eb9d43d2bb261d3d9cd2b5a3e147a2.tar.gz";
+  sha256 = "0yirimlkifhrmsxxmqrjra7a99mfwkc5p09hamapday8svzdaycv";
 }) { }
 

--- a/src/FLA/Data/Vec/Properties.agda
+++ b/src/FLA/Data/Vec/Properties.agda
@@ -28,6 +28,7 @@ private
 --                              take/drop proofs                             --
 -------------------------------------------------------------------------------
 
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 take-distr-zipWith : (f : A → B → C)
                    → (u : Vec A (m + n))
                    → (v : Vec B (m + n))
@@ -48,6 +49,7 @@ take-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) =
       zipWith f (take (suc m) (u ∷ us)) (take (suc m) (v ∷ vs))
   ∎
 
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 drop-distr-zipWith : (f : A → B → C)
                    → (u : Vec A (m + n))
                    → (v : Vec B (m + n))
@@ -66,6 +68,7 @@ drop-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) =
       zipWith f (drop (suc m) (u ∷ us)) (drop (suc m) (v ∷ vs))
   ∎
 
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 take-distr-map : (f : A → B) → (m : ℕ) → (v : Vec A (m + n))
                → take m (map f v) ≡ map f (take m v)
 take-distr-map f zero v = refl
@@ -78,6 +81,7 @@ take-distr-map f (suc m) (v ∷ vs) =
     map f (v ∷ take m vs)         ≡⟨ cong (map f) (sym (unfold-take m v vs)) ⟩
     map f (take (suc m) (v ∷ vs)) ∎
 
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 drop-distr-map : (f : A → B) → (m : ℕ) → (v : Vec A (m + n))
                → drop m (map f v) ≡ map f (drop m v)
 drop-distr-map f zero v = refl
@@ -89,7 +93,7 @@ drop-distr-map f (suc m) (v ∷ vs) =
     map f (drop m vs)             ≡⟨ cong (map f) (sym (unfold-drop m v vs)) ⟩
     map f (drop (suc m) (v ∷ vs)) ∎
 
-
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 take-drop-id : (m : ℕ) → (v : Vec A (m + n)) → take m v ++ drop m v ≡ v
 take-drop-id zero v = refl
 take-drop-id (suc m) (v ∷ vs) =
@@ -103,6 +107,7 @@ take-drop-id (suc m) (v ∷ vs) =
     (v ∷ vs)
   ∎
 
+-- TODO: Remove with agda-stdlib 1.5. Merged upstream in that release.
 zipWith-replicate : ∀ {a b c : Level} {A : Set a} {B : Set b} {C : Set c} {n : ℕ} (_⊕_ : A → B → C) (x : A) (y : B)
                   → zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
 zipWith-replicate {n = zero} _⊕_ x y = refl

--- a/src/FLA/Data/Vec/Properties.agda
+++ b/src/FLA/Data/Vec/Properties.agda
@@ -10,6 +10,7 @@ open import Data.Nat.Properties
 
 open import Data.Product using (_,_)
 open import Data.Vec using (Vec; foldr; zipWith; map; []; _∷_; _++_; take; drop; splitAt; replicate)
+open import Data.Vec.Properties
 
 module FLA.Data.Vec.Properties where
 
@@ -26,18 +27,6 @@ private
 -------------------------------------------------------------------------------
 --                              take/drop proofs                             --
 -------------------------------------------------------------------------------
-
--- TODO: replace with Agda stdlib 1.4 version once released.
-unfold-take : ∀ n {m} x (xs : Vec A (n + m))
-            → take (suc n) (x ∷ xs) ≡ x ∷ take n xs
-unfold-take n x xs with splitAt n xs
-unfold-take n x .(xs ++ ys) | xs , ys , refl = refl
-
--- TODO: replace with Agda stdlib 1.4 version once released.
-unfold-drop : ∀ n {m} x (xs : Vec A (n + m))
-            → drop (suc n) (x ∷ xs) ≡ drop n xs
-unfold-drop n x xs with splitAt n xs
-unfold-drop n x .(xs ++ ys) | xs , ys , refl = refl
 
 take-distr-zipWith : (f : A → B → C)
                    → (u : Vec A (m + n))


### PR DESCRIPTION
This means that some of the copied functions can be removed.