### PR TITLE
Add dependencies section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ cachix use functional-linear-algebra
 ```
 
 
+### Dependencies
+
+The following Agda libraries are used:
+
+- `agda-stdlib==1.4`
+
+
 Want to contribute?
 -------------------
 


### PR DESCRIPTION
The standard library does not include the version number
in the name. Hence the version cannot be specified in the .lib file. See
the Agda docs for more details.

https://agda.readthedocs.io/en/v2.6.1.1/tools/package-system.html