### PR TITLE
Update agda stdlib 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cachix use functional-linear-algebra
 
 The following Agda libraries are used:
 
-- `agda-stdlib==1.4`
+- `agda-stdlib==1.6`
 
 
 Want to contribute?

--- a/functional-linear-algebra.agda-lib
+++ b/functional-linear-algebra.agda-lib
@@ -1,3 +1,3 @@
 name: functional-linear-algebra
-depend: standard-library-1.5
+depend: standard-library-1.6
 include: src


### PR DESCRIPTION
stdlib 1.6-rc1 is out. No source changes needed! :-)

Could you cut a new release, so that we can use it in Nix?