### PR TITLE
Standard-library 1.6-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ cachix use functional-linear-algebra
 
 The following Agda libraries are used:
 
-- `standard-library-1.5`
+- `standard-library-1.6`
+
+You can override which specific version of the standard library is being used
+through Nix by changing the `use-overlay-standard-library` boolean in
+`agda-stardard-library.nix` and updating the git revision to the one you'd like
+to use.
 
 
 Want to contribute?

--- a/agda-stardard-library.nix
+++ b/agda-stardard-library.nix
@@ -1,0 +1,18 @@
+let
+
+  use-overlay-standard-library = true;
+
+in pkgs:
+if use-overlay-standard-library then {
+  version = "1.6";
+  src = pkgs.fetchFromGitHub {
+    repo = "agda-stdlib";
+    owner = "agda";
+
+    # v1.6-rc1
+    rev = "bfb790f8d07e96710cabf5915af4c51b2a1b9643";
+    sha256 = "1vb84jqv3qpbd40ir1wj3rwj3wmzs8s57whwl4hssk5r8dimxng3";
+  };
+} else
+  { }
+

--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,8 @@
 { pkgs }:
 
 pkgs.agdaPackages.functional-linear-algebra.overrideAttrs (oldAttrs: rec {
+  version = "0.3";
+
   src = pkgs.lib.sourceFilesBySuffices ./. [
     ".agda"
     ".lagda"

--- a/functional-linear-algebra.agda-lib
+++ b/functional-linear-algebra.agda-lib
@@ -1,3 +1,3 @@
 name: functional-linear-algebra
-depend: standard-library-1.5
+depend: standard-library-1.6
 include: src

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -6,17 +6,7 @@ let
   agda-standard-library-1-6-overlay = (self: super: {
     agdaPackages = super.agdaPackages // {
       standard-library = super.agdaPackages.standard-library.overrideAttrs
-        (old: {
-          version = "1.6";
-          src = super.fetchFromGitHub {
-            repo = "agda-stdlib";
-            owner = "agda";
-
-            # v1.6-rc1
-            rev = "bfb790f8d07e96710cabf5915af4c51b2a1b9643";
-            sha256 = "1vb84jqv3qpbd40ir1wj3rwj3wmzs8s57whwl4hssk5r8dimxng3";
-          };
-        });
+        (old: import ./agda-stardard-library.nix super);
 
       functional-linear-algebra =
         super.agdaPackages.functional-linear-algebra.override ({

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,7 +1,32 @@
 # nixpkgs unstable channel from April 16th, 2021
-import (builtins.fetchTarball {
+
+let
+
+  # Temporary workaround while Agda standard library is an RC.
+  agda-standard-library-1-6-overlay = (self: super: {
+    agdaPackages = super.agdaPackages // {
+      standard-library = super.agdaPackages.standard-library.overrideAttrs
+        (old: {
+          version = "1.6";
+          src = super.fetchFromGitHub {
+            repo = "agda-stdlib";
+            owner = "agda";
+
+            # v1.6-rc1
+            rev = "bfb790f8d07e96710cabf5915af4c51b2a1b9643";
+            sha256 = "1vb84jqv3qpbd40ir1wj3rwj3wmzs8s57whwl4hssk5r8dimxng3";
+          };
+        });
+
+      functional-linear-algebra =
+        super.agdaPackages.functional-linear-algebra.override ({
+          standard-library = self.agdaPackages.standard-library;
+        });
+    };
+  });
+
+in import (builtins.fetchTarball {
   url =
     "https://github.com/NixOS/nixpkgs/archive/e5cc06a1e806070693add4f231060a62b962fc44.tar.gz";
   sha256 = "04543i332fx9m7jf6167ac825s4qb8is0d0x0pz39il979mlc87v";
-}) { }
-
+}) { overlays = [ agda-standard-library-1-6-overlay ]; }


### PR DESCRIPTION
Add an overlay with Agda standard library 1.6-rc1. After this is merged, version 0.3 should be compatible with nixpkgs once nixpkgs updates the standard library.