### PR TITLE
Remove upper bound on agda-stdlib (1.7 compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cachix use functional-linear-algebra
 
 The following Agda libraries are used:
 
-- `standard-library-1.6`
+- `standard-library` (tested up to v1.7)
 
 You can override which specific version of the standard library is being used
 through Nix by changing the `use-overlay-standard-library` boolean in

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 { pkgs }:
 
 pkgs.agdaPackages.functional-linear-algebra.overrideAttrs (oldAttrs: rec {
-  version = "0.3";
+  version = "0.4";
 
   src = pkgs.lib.sourceFilesBySuffices ./. [
     ".agda"
@@ -18,4 +18,8 @@ pkgs.agdaPackages.functional-linear-algebra.overrideAttrs (oldAttrs: rec {
     # Find all .agda files in the src/ directory and put it in Everything.agda
     ./generate-everything.sh
   '';
+
+  # Force the meta to be unbroken so that the package will always attempt to
+  # build in CI, regardless of the upstream broken status.
+  meta.broken = false;
 })

--- a/functional-linear-algebra.agda-lib
+++ b/functional-linear-algebra.agda-lib
@@ -1,3 +1,3 @@
 name: functional-linear-algebra
-depend: standard-library-1.6
+depend: standard-library
 include: src

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,4 +1,5 @@
-# nixpkgs unstable channel from April 16th, 2021
+# nixpkgs unstable channel from July 24th, 2021
+# specifically set to test the bump to the agda-stdlib 1.7
 
 let
 
@@ -17,6 +18,6 @@ let
 
 in import (builtins.fetchTarball {
   url =
-    "https://github.com/NixOS/nixpkgs/archive/1c65a509fbbc17a2853a657ea1391de0aab9e793.tar.gz";
-  sha256 = "16393rlq9zq8cs3hapd614bjchmxzkfzn9nawa81rxc7zb2khwqm";
+    "https://github.com/NixOS/nixpkgs/archive/703882fb577fc939ace7cdc3197440f306380b9b.tar.gz";
+  sha256 = "0141ip3wfaj1pvh2681kdhhj4lwwwjdrchmgg5xnd9zmazvk2nsc";
 }) { overlays = [ agda-standard-library-overlay ]; }


### PR DESCRIPTION
The upper bound mostly caused some issues related to the nixpkgs moving faster
than this package. Removing the  upper bound so ideally nixpkgs does not need
to be updated as often.