### PR TITLE
Agda stdlib 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,11 @@ MAlonzo/**
 # Nix
 result
 
-# direnv
-.direnv/
+# Created by https://www.toptal.com/developers/gitignore/api/emacs,vim,visualstudiocode,macos,linux,windows,direnv
+# Edit at https://www.toptal.com/developers/gitignore?templates=emacs,vim,visualstudiocode,macos,linux,windows,direnv
 
-# Created by https://www.toptal.com/developers/gitignore/api/emacs,vim,visualstudiocode,macos
-# Edit at https://www.toptal.com/developers/gitignore?templates=emacs,vim,visualstudiocode,macos
+### direnv ###
+.direnv
 
 ### Emacs ###
 # -*- mode: gitignore; -*-
@@ -63,6 +63,20 @@ flycheck_*.el
 /network-security.data
 
 
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
 ### macOS ###
 # General
 .DS_Store
@@ -92,6 +106,10 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
@@ -114,13 +132,47 @@ tags
 
 ### VisualStudioCode ###
 .vscode/*
+!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
-*.code-workspace
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
 
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history
 .ionide
 
-# End of https://www.toptal.com/developers/gitignore/api/emacs,vim,visualstudiocode,macos
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/emacs,vim,visualstudiocode,macos,linux,windows,direnv

--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ installed.
 
 ### Use Nix to get Agda installed
 
-This repository includes a shell file that will make the `agda` 2.6.1 binary
+This repository includes a shell file that will make the `agda` 2.6.4.1 binary
 available. Simply type `nix-shell` to get started.
 
 It is recommended that you use emacs to write Agda code, although any editor
-with [agda-mode][agda-mode] support will work. If you have `spacemacs` you
-can activate the `agda` configuration layer.
+with [agda-mode][agda-mode] support will work.
 
 
 ### How to include this library in other Agda libraries
@@ -59,20 +58,11 @@ This library can be included in other Agda packages using either the
 be found in the [Agda section of the nixpkgs manual][nixpkgs-agda].
 
 
-### Cachix
-
-This library uses cachix. To use the cache, install cachix and then run
-
-```
-cachix use functional-linear-algebra
-```
-
-
 ### Dependencies
 
 The following Agda libraries are used:
 
-- `standard-library` (tested up to v1.7)
+- `standard-library` (version 2.0 only, does not work with the 1.x series)
 
 You can override which specific version of the standard library is being used
 through Nix by changing the `use-overlay-standard-library` boolean in
@@ -100,8 +90,7 @@ please submit a pull request! I would like to get to the following at some point
 [presentation]: https://github.com/ryanorendorff/lc-2020-linear-algebra-agda
 
 <!-- References -->
-[agda-mode]: https://agda.readthedocs.io/en/v2.6.1/tools/emacs-mode.html
+[agda-mode]: https://agda.readthedocs.io/en/v2.6.4.1/tools/emacs-mode.html
 [nix]: https://nixos.org
 [nixpkgs]: https://github.com/nixos/nixpkgs
 [nixpkgs-agda]: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/agda.section.md
-[spacemacs]: https://www.spacemacs.org/

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 { agdaPackages, lib }:
 
 agdaPackages.functional-linear-algebra.overrideAttrs (oldAttrs: rec {
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = lib.sourceFilesBySuffices (builtins.path {
     path = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,12 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs { inherit system; };
+      let
+        nixpkgs-patched = (import nixpkgs { inherit system; }).applyPatches {
+          name = "patches";
+          src = nixpkgs;
+          patches = [ ./nix-patches/273765.patch ];
+        };
+        pkgs = import nixpkgs-patched { inherit system; };
       in { packages.default = pkgs.callPackage ./default.nix { }; });
 }

--- a/nix-patches/273765.patch
+++ b/nix-patches/273765.patch
@@ -1,0 +1,36 @@
+From 38baa1f3af43f967824b1b3ecfadf94717dfe2e1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Na=C3=AFm=20Favier?= <n@monade.li>
+Date: Tue, 12 Dec 2023 15:02:12 +0100
+Subject: [PATCH] agdaPackages.standard-library: 1.7.3 -> 2.0
+
+https://github.com/agda/agda-stdlib/blob/v2.0/CHANGELOG.md
+---
+ .../development/libraries/agda/standard-library/default.nix | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pkgs/development/libraries/agda/standard-library/default.nix b/pkgs/development/libraries/agda/standard-library/default.nix
+index 10fd1034ebe2a2..d7b49893b96f79 100644
+--- a/pkgs/development/libraries/agda/standard-library/default.nix
++++ b/pkgs/development/libraries/agda/standard-library/default.nix
+@@ -2,18 +2,18 @@
+ 
+ mkDerivation rec {
+   pname = "standard-library";
+-  version = "1.7.3";
++  version = "2.0";
+ 
+   src = fetchFromGitHub {
+     repo = "agda-stdlib";
+     owner = "agda";
+     rev = "v${version}";
+-    hash = "sha256-vtL6VPvTXhl/mepulUm8SYyTjnGsqno4RHDmTIy22Xg=";
++    hash = "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=";
+   };
+ 
+   nativeBuildInputs = [ (ghcWithPackages (self : [ self.filemanip ])) ];
+   preConfigure = ''
+-    runhaskell GenerateEverything.hs
++    runhaskell GenerateEverything.hs --include-deprecated
+     # We will only build/consider Everything.agda, in particular we don't want Everything*.agda
+     # do be copied to the store.
+     rm EverythingSafe.agda

--- a/src/FLA/Algebra/LinearAlgebra/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Matrix.agda
@@ -177,7 +177,7 @@ module _ ⦃ F : Field A ⦄ where
           ≡⟨ ⟨a,b⟩+⟨c,d⟩≡⟨a++c,b++d⟩ (take n y) (M₁ᵀ ·ˡᵐ x)
                                      (drop n y) (M₂ᵀ ·ˡᵐ x) ⟩
             ⟨ take n y ++ drop n y , M₁ᵀ ·ˡᵐ x ++ M₂ᵀ ·ˡᵐ x ⟩
-          ≡⟨ cong (λ a → ⟨ a , M₁ᵀ ·ˡᵐ x ++ M₂ᵀ ·ˡᵐ x ⟩) (take-drop-id n y) ⟩
+          ≡⟨ cong (λ a → ⟨ a , M₁ᵀ ·ˡᵐ x ++ M₂ᵀ ·ˡᵐ x ⟩) (take++drop≡id n y) ⟩
             ⟨ y , M₁ᵀ ·ˡᵐ x ++ M₂ᵀ ·ˡᵐ x ⟩
           ≡⟨⟩
             ⟨ y , (M₁ᵀ —ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
@@ -208,7 +208,7 @@ module _ ⦃ F : Field A ⦄ where
           ≡⟨⟩
             ⟨ x , M₁ ·ˡᵐ take n y ++ M₂ ·ˡᵐ drop n y ⟩
           ≡⟨ cong (λ x → ⟨ x , M₁ ·ˡᵐ take n y ++ M₂ ·ˡᵐ drop n y ⟩)
-                  (sym (take-drop-id m x)) ⟩
+                  (sym (take++drop≡id m x)) ⟩
             ⟨ take m x ++ drop m x , M₁ ·ˡᵐ (take n y) ++ M₂ ·ˡᵐ drop n y ⟩
           ≡⟨ ⟨a++b,c++d⟩≡⟨a,c⟩+⟨b,d⟩ (take m x) (drop m x)
                                      (M₁ ·ˡᵐ (take n y)) (M₂ ·ˡᵐ drop n y) ⟩
@@ -220,7 +220,7 @@ module _ ⦃ F : Field A ⦄ where
                                      (drop n y) (M₂ᵀ ·ˡᵐ  drop m x) ⟩
             ⟨ take n y ++ drop n y , M₁ᵀ ·ˡᵐ take m x ++ M₂ᵀ ·ˡᵐ  drop m x ⟩
           ≡⟨ cong (λ y → ⟨ y , M₁ᵀ ·ˡᵐ take m x ++ M₂ᵀ ·ˡᵐ  drop m x ⟩)
-                  (take-drop-id n y) ⟩
+                  (take++drop≡id n y) ⟩
             ⟨ y , M₁ᵀ ·ˡᵐ (take m x) ++ M₂ᵀ ·ˡᵐ (drop m x) ⟩
           ≡⟨⟩
             ⟨ y , (M₁ᵀ /ˡᵐ M₂ᵀ) ·ˡᵐ x ⟩
@@ -297,17 +297,17 @@ module _ ⦃ F : Field A ⦄ where
 
       1ₗₘ-transpose : (x : Vec A m) (y : Vec A n)
                     → ⟨ x , 1ₗₘ ·ˡᵐ y ⟩ ≡ ⟨ y , 1ₗₘ ·ˡᵐ x ⟩
-      1ₗₘ-transpose x y = begin
+      1ₗₘ-transpose {m = m} {n = n} x y = begin
           ⟨ x , 1ₗₘ ·ˡᵐ y ⟩            ≡⟨⟩
-          sum (x *ⱽ replicate (sum y)) ≡⟨ cong sum (zip-rep _*_ x (sum y)) ⟩
-          sum (map (_* sum y) x)       ≡⟨ cong sum (map-*c-≡c∘ⱽ (sum y) x) ⟩
-          sum (sum y ∘ⱽ x)             ≡⟨ sum[c∘ⱽv]≡c*sum[v] (sum y) x ⟩
-          sum y * sum x                ≡⟨ *-comm (sum y) (sum x) ⟩
-          sum x * sum y                ≡˘⟨ sum[c∘ⱽv]≡c*sum[v] (sum x) y ⟩
-          sum (sum x ∘ⱽ y)             ≡˘⟨ cong sum (map-*c-≡c∘ⱽ (sum x) y) ⟩
-          sum (map (_* sum x) y)       ≡˘⟨ cong sum (zip-rep _*_ y (sum x)) ⟩
-          sum (y *ⱽ replicate (sum x)) ≡⟨⟩
-          ⟨ y , 1ₗₘ ·ˡᵐ x ⟩            ∎
+          sum (x *ⱽ replicate m (sum y)) ≡⟨ cong sum (zip-rep _*_ x (sum y)) ⟩
+          sum (map (_* sum y) x)         ≡⟨ cong sum (map-*c-≡c∘ⱽ (sum y) x) ⟩
+          sum (sum y ∘ⱽ x)               ≡⟨ sum[c∘ⱽv]≡c*sum[v] (sum y) x ⟩
+          sum y * sum x                  ≡⟨ *-comm (sum y) (sum x) ⟩
+          sum x * sum y                  ≡˘⟨ sum[c∘ⱽv]≡c*sum[v] (sum x) y ⟩
+          sum (sum x ∘ⱽ y)               ≡˘⟨ cong sum (map-*c-≡c∘ⱽ (sum x) y) ⟩
+          sum (map (_* sum x) y)         ≡˘⟨ cong sum (zip-rep _*_ y (sum x)) ⟩
+          sum (y *ⱽ replicate n (sum x)) ≡⟨⟩
+          ⟨ y , 1ₗₘ ·ˡᵐ x ⟩              ∎
 
   0ᴹ : Mat m × n
   0ᴹ = ⟦ 0ₗₘ , 0ₗₘ , 0ₗₘ-transpose ⟧
@@ -315,10 +315,10 @@ module _ ⦃ F : Field A ⦄ where
       0ₗₘ-transpose : (x : Vec A m) (y : Vec A n)
                     → ⟨ x , 0ₗₘ ·ˡᵐ y ⟩ ≡ ⟨ y , 0ₗₘ ·ˡᵐ x ⟩
       0ₗₘ-transpose {m = m} {n = n} x y = begin
-        ⟨ x , 0ₗₘ ·ˡᵐ y ⟩               ≡⟨⟩
-        sum (x *ⱽ replicate 0ᶠ)         ≡⟨ cong sum (v*ⱽ0ᶠⱽ≡0ᶠⱽ x) ⟩
-        sum (replicate {n = m} 0ᶠ)      ≡⟨ sum[0ᶠⱽ]≡0ᶠ {n = m} ⟩
-        0ᶠ                              ≡˘⟨ sum[0ᶠⱽ]≡0ᶠ {n = n} ⟩
-        sum (replicate {n = n} 0ᶠ)      ≡˘⟨ cong sum (v*ⱽ0ᶠⱽ≡0ᶠⱽ y) ⟩
-        sum (y *ⱽ replicate {n = n} 0ᶠ) ≡⟨⟩
-        ⟨ y , 0ₗₘ ·ˡᵐ x ⟩               ∎
+        ⟨ x , 0ₗₘ ·ˡᵐ y ⟩         ≡⟨⟩
+        sum (x *ⱽ replicate m 0ᶠ) ≡⟨ cong sum (v*ⱽ0ᶠⱽ≡0ᶠⱽ x) ⟩
+        sum (replicate m 0ᶠ)      ≡⟨ sum[0ᶠⱽ]≡0ᶠ {n = m} ⟩
+        0ᶠ                        ≡˘⟨ sum[0ᶠⱽ]≡0ᶠ {n = n} ⟩
+        sum (replicate n 0ᶠ)      ≡˘⟨ cong sum (v*ⱽ0ᶠⱽ≡0ᶠⱽ y) ⟩
+        sum (y *ⱽ replicate n 0ᶠ) ≡⟨⟩
+        ⟨ y , 0ₗₘ ·ˡᵐ x ⟩         ∎

--- a/src/FLA/Algebra/LinearAlgebra/Properties.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties.agda
@@ -41,22 +41,22 @@ module _ ⦃ F : Field A ⦄ where
       x₁ + x₂ ∷ vs₂ +ⱽ vs₁ ≡⟨ cong (_∷ vs₂ +ⱽ vs₁) (+-comm x₁ x₂) ⟩
       x₂ + x₁ ∷ vs₂ +ⱽ vs₁ ∎
 
-  v+0ᶠⱽ≡v : (v : Vec A n) → v +ⱽ (replicate 0ᶠ) ≡ v
+  v+0ᶠⱽ≡v : (v : Vec A n) → v +ⱽ (replicate n 0ᶠ) ≡ v
   v+0ᶠⱽ≡v [] = refl
   v+0ᶠⱽ≡v (v ∷ vs) = cong₂ _∷_ (+0ᶠ v) (v+0ᶠⱽ≡v vs)
 
-  0ᶠⱽ+v≡v : (v : Vec A n) → (replicate 0ᶠ) +ⱽ v ≡ v
-  0ᶠⱽ+v≡v v = trans (+ⱽ-comm (replicate 0ᶠ) v) (v+0ᶠⱽ≡v v)
+  0ᶠⱽ+v≡v : (v : Vec A n) → (replicate n 0ᶠ) +ⱽ v ≡ v
+  0ᶠⱽ+v≡v {n = n} v = trans (+ⱽ-comm (replicate n 0ᶠ) v) (v+0ᶠⱽ≡v v)
 
-  0ᶠ∘ⱽv≡0ᶠⱽ : (v : Vec A n) → 0ᶠ ∘ⱽ v ≡ replicate 0ᶠ
+  0ᶠ∘ⱽv≡0ᶠⱽ : (v : Vec A n) → 0ᶠ ∘ⱽ v ≡ replicate n 0ᶠ
   0ᶠ∘ⱽv≡0ᶠⱽ [] = refl
   0ᶠ∘ⱽv≡0ᶠⱽ (v ∷ vs) = cong₂ _∷_ (0ᶠ*a≡0ᶠ v) (0ᶠ∘ⱽv≡0ᶠⱽ vs)
 
-  c∘ⱽ0ᶠⱽ≡0ᶠⱽ : {n : ℕ} → (c : A) → c ∘ⱽ replicate {n = n} 0ᶠ ≡ replicate 0ᶠ
+  c∘ⱽ0ᶠⱽ≡0ᶠⱽ : {n : ℕ} → (c : A) → c ∘ⱽ replicate n 0ᶠ ≡ replicate n 0ᶠ
   c∘ⱽ0ᶠⱽ≡0ᶠⱽ {zero} c = refl
   c∘ⱽ0ᶠⱽ≡0ᶠⱽ {suc n} c = cong₂ _∷_ (a*0ᶠ≡0ᶠ c) (c∘ⱽ0ᶠⱽ≡0ᶠⱽ c)
 
-  v*ⱽ0ᶠⱽ≡0ᶠⱽ : {n : ℕ} → (v : Vec A n) → v *ⱽ replicate 0ᶠ ≡ replicate 0ᶠ
+  v*ⱽ0ᶠⱽ≡0ᶠⱽ : {n : ℕ} → (v : Vec A n) → v *ⱽ replicate n 0ᶠ ≡ replicate n 0ᶠ
   v*ⱽ0ᶠⱽ≡0ᶠⱽ [] = refl
   v*ⱽ0ᶠⱽ≡0ᶠⱽ (v ∷ vs) = cong₂ _∷_ (a*0ᶠ≡0ᶠ v) (v*ⱽ0ᶠⱽ≡0ᶠⱽ vs)
 
@@ -65,7 +65,7 @@ module _ ⦃ F : Field A ⦄ where
   map-*c-≡c∘ⱽ c (v ∷ vs) = cong₂ _∷_ (*-comm v c) (map-*c-≡c∘ⱽ c vs)
 
   replicate-distr-+ : {n : ℕ} → (u v : A)
-                    → replicate {n = n} (u + v) ≡ replicate u +ⱽ replicate v
+                    → replicate n (u + v) ≡ replicate n u +ⱽ replicate n v
   replicate-distr-+ u v = sym (zipWith-replicate _+_ u v)
 
   -- This should work for any linear function (I think), instead of just -_,
@@ -167,21 +167,21 @@ module _ ⦃ F : Field A ⦄ where
   ∘ⱽ-distr-++ c (a ∷ as) b rewrite ∘ⱽ-distr-++ c as b = refl
 
   replicate[a*b]≡a∘ⱽreplicate[b] : {n : ℕ} (a b : A) →
-                                   replicate {n = n} (a * b) ≡ a ∘ⱽ replicate b
+                                   replicate n (a * b) ≡ a ∘ⱽ replicate n b
   replicate[a*b]≡a∘ⱽreplicate[b] {n = n} a b = sym (map-replicate (a *_) b n)
 
   replicate[a*b]≡b∘ⱽreplicate[a] : {n : ℕ} (a b : A) →
-                                   replicate {n = n} (a * b) ≡ b ∘ⱽ replicate a
-  replicate[a*b]≡b∘ⱽreplicate[a] a b = trans (cong replicate (*-comm a b))
-                                             (replicate[a*b]≡a∘ⱽreplicate[b] b a)
+                                   replicate n (a * b) ≡ b ∘ⱽ replicate n a
+  replicate[a*b]≡b∘ⱽreplicate[a] {n = n} a b = trans (cong (replicate n) (*-comm a b))
+                                               (replicate[a*b]≡a∘ⱽreplicate[b] b a)
 
-  sum[0ᶠⱽ]≡0ᶠ : {n : ℕ} → sum (replicate {n = n} 0ᶠ) ≡ 0ᶠ
+  sum[0ᶠⱽ]≡0ᶠ : {n : ℕ} → sum (replicate n 0ᶠ) ≡ 0ᶠ
   sum[0ᶠⱽ]≡0ᶠ {n = zero} = refl
   sum[0ᶠⱽ]≡0ᶠ {n = suc n} = begin
-      sum (0ᶠ ∷ replicate {n = n} 0ᶠ) ≡⟨⟩
-      0ᶠ + sum (replicate {n = n} 0ᶠ) ≡⟨ cong (0ᶠ +_) (sum[0ᶠⱽ]≡0ᶠ {n})  ⟩
-      0ᶠ + 0ᶠ                         ≡⟨ 0ᶠ+0ᶠ≡0ᶠ ⟩
-      0ᶠ                              ∎
+      sum (0ᶠ ∷ replicate n 0ᶠ) ≡⟨⟩
+      0ᶠ + sum (replicate n 0ᶠ) ≡⟨ cong (0ᶠ +_) (sum[0ᶠⱽ]≡0ᶠ {n})  ⟩
+      0ᶠ + 0ᶠ                   ≡⟨ 0ᶠ+0ᶠ≡0ᶠ ⟩
+      0ᶠ                        ∎
 
   sum-distr-+ⱽ : (v₁ v₂ : Vec A n) → sum (v₁ +ⱽ v₂) ≡ sum v₁ + sum v₂
   sum-distr-+ⱽ [] [] = sym (0ᶠ+0ᶠ≡0ᶠ)

--- a/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
+++ b/src/FLA/Algebra/LinearAlgebra/Properties/Matrix.agda
@@ -2,7 +2,7 @@
 
 open import Axiom.UniquenessOfIdentityProofs.WithK using (uip)
 
-open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
 open import Level using (Level)

--- a/src/FLA/Algebra/LinearMap.agda
+++ b/src/FLA/Algebra/LinearMap.agda
@@ -4,7 +4,7 @@
 -- for the fields that we want (real numbers)
 open import Level using (Level)
 
-open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
 open import Data.Nat using (ℕ) renaming (_+_ to _+ᴺ_)
@@ -204,7 +204,7 @@ module _ ⦃ F : Field A ⦄ where
         f[u+v]≡f[u]+f[v]' {m} T B u v = begin
             T ·ˡᵐ (take m (u +ⱽ v)) +ⱽ B ·ˡᵐ (drop m (u +ⱽ v))
           ≡⟨ cong₂ (λ x y → T ·ˡᵐ x +ⱽ B ·ˡᵐ y)
-                   (take-distr-zipWith _+_ u v) (drop-distr-zipWith _+_ u v)⟩
+                   (take-zipWith _+_ u v) (drop-zipWith _+_ u v)⟩
             T ·ˡᵐ (take m u +ⱽ take m v) +ⱽ B ·ˡᵐ (drop m u +ⱽ drop m v)
           ≡⟨ cong₂ _+ⱽ_ (f[u+v]≡f[u]+f[v] T (take m u) (take m v))
                         (f[u+v]≡f[u]+f[v] B (drop m u) (drop m v)) ⟩
@@ -241,8 +241,8 @@ module _ ⦃ F : Field A ⦄ where
                           c ∘ⱽ (T ·ˡᵐ take m v +ⱽ B ·ˡᵐ drop m v)
         f[c*v]≡c*f[v]' {m} T B c v = begin
             T ·ˡᵐ take m (c ∘ⱽ v) +ⱽ B ·ˡᵐ drop m (c ∘ⱽ v)
-          ≡⟨ cong₂ (λ x y → T ·ˡᵐ x +ⱽ B ·ˡᵐ y) (take-distr-map (c *_) m v)
-                                                 (drop-distr-map (c *_) m v) ⟩
+          ≡⟨ cong₂ (λ x y → T ·ˡᵐ x +ⱽ B ·ˡᵐ y) (take-map (c *_) m v)
+                                                 (drop-map (c *_) m v) ⟩
             T ·ˡᵐ (c ∘ⱽ take m v) +ⱽ B ·ˡᵐ (c ∘ⱽ drop m v)
           ≡⟨ cong₂ _+ⱽ_ (f[c*v]≡c*f[v] T c (take m v))
                         (f[c*v]≡c*f[v] B c (drop m v)) ⟩
@@ -270,7 +270,7 @@ module _ ⦃ F : Field A ⦄ where
           begin
               T ·ˡᵐ take m (u +ⱽ v) ++ B ·ˡᵐ drop m (u +ⱽ v)
             ≡⟨ cong₂ (λ x y → T ·ˡᵐ x ++ B ·ˡᵐ y)
-                     (take-distr-zipWith _+_ u v) (drop-distr-zipWith _+_ u v)⟩
+                     (take-zipWith _+_ u v) (drop-zipWith _+_ u v)⟩
               T ·ˡᵐ (take m u +ⱽ take m v) ++ B ·ˡᵐ (drop m u +ⱽ drop m v)
             ≡⟨ cong₂ _++_ (f[u+v]≡f[u]+f[v] T (take m u) (take m v))
                           (f[u+v]≡f[u]+f[v] B (drop m u) (drop m v)) ⟩
@@ -290,8 +290,8 @@ module _ ⦃ F : Field A ⦄ where
         f[c*v]≡c*f[v]' {m} T B c v =
           begin
               T ·ˡᵐ take m (c ∘ⱽ v) ++ B ·ˡᵐ drop m (c ∘ⱽ v)
-            ≡⟨ cong₂ (λ x y → T ·ˡᵐ x ++ B ·ˡᵐ y) (take-distr-map (c *_) m v)
-                                                   (drop-distr-map (c *_) m v) ⟩
+            ≡⟨ cong₂ (λ x y → T ·ˡᵐ x ++ B ·ˡᵐ y) (take-map (c *_) m v)
+                                                   (drop-map (c *_) m v) ⟩
               T ·ˡᵐ (c ∘ⱽ take m v) ++ B ·ˡᵐ (c ∘ⱽ (drop m v))
             ≡⟨ cong₂ _++_ (f[c*v]≡c*f[v] T c (take m v))
                           (f[c*v]≡c*f[v] B c (drop m v)) ⟩
@@ -342,35 +342,44 @@ module _ ⦃ F : Field A ⦄ where
     ; f[c*v]≡c*f[v] = λ c v → *ⱽ∘ⱽ≡∘ⱽ*ⱽ c d v
     }
 
-  1ₗₘ : n ⊸ m
+  1ₗₘ : m ⊸ n
   1ₗₘ = record
-    { f = λ v → replicate (sum v)
+    { f = f
     ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]
     ; f[c*v]≡c*f[v] = f[c*v]≡c*f[v]
     }
     where
-      f[u+v]≡f[u]+f[v] : (u v : Vec A n)
-                       → replicate (sum (u +ⱽ v)) ≡
-                          replicate (sum u) +ⱽ replicate (sum v)
-      f[u+v]≡f[u]+f[v] u v = begin
-        replicate (sum (u +ⱽ v))      ≡⟨ cong replicate (sum-distr-+ⱽ u v) ⟩
-        replicate ((sum u) + (sum v)) ≡⟨ replicate-distr-+ (sum u) (sum v) ⟩
-        replicate (sum u) +ⱽ replicate (sum v) ∎
+      f : (Vec A m → Vec A n)
+      f {n = n} v = replicate n (sum v)
 
-      f[c*v]≡c*f[v] : (c : A) (v : Vec A n)
-                    → replicate (sum (c ∘ⱽ v)) ≡ c ∘ⱽ replicate (sum v)
-      f[c*v]≡c*f[v] c v = begin
-        replicate (sum (c ∘ⱽ v)) ≡⟨ cong replicate (sum[c∘ⱽv]≡c*sum[v] c v) ⟩
-        replicate (c * sum v)    ≡⟨ replicate[a*b]≡a∘ⱽreplicate[b] c (sum v) ⟩
-        c ∘ⱽ replicate (sum v)   ∎
+      f[u+v]≡f[u]+f[v] : (u v : Vec A m)
+                       → replicate n (sum (u +ⱽ v)) ≡
+                          replicate n (sum u) +ⱽ replicate n (sum v)
+      f[u+v]≡f[u]+f[v] {n = n} u v = begin
+        replicate n (sum (u +ⱽ v))      ≡⟨ cong (replicate n) (sum-distr-+ⱽ u v) ⟩
+        replicate n ((sum u) + (sum v)) ≡⟨ replicate-distr-+ (sum u) (sum v) ⟩
+        replicate n (sum u) +ⱽ replicate n (sum v) ∎
+
+      f[c*v]≡c*f[v] : (c : A) (v : Vec A m)
+                    → replicate n (sum (c ∘ⱽ v)) ≡ c ∘ⱽ replicate n (sum v)
+      f[c*v]≡c*f[v] {n = n} c v = begin
+        replicate n (sum (c ∘ⱽ v)) ≡⟨ cong (replicate n) (sum[c∘ⱽv]≡c*sum[v] c v) ⟩
+        replicate n (c * sum v)    ≡⟨ replicate[a*b]≡a∘ⱽreplicate[b] c (sum v) ⟩
+        c ∘ⱽ replicate n (sum v)   ∎
 
   -- This could be defined as 0ᶠ ∘ˡᵐ allonesₗₘ, but then that would make
   -- some later proofs more difficult, since they would then have more than
   -- just replicate 0ᶠ to replace zerosₗₘ with.
-  0ₗₘ : n ⊸ m
-  0ₗₘ =  record
-    { f = λ v → replicate 0ᶠ
-    ; f[u+v]≡f[u]+f[v] = λ u v → sym (trans (zipWith-replicate _+_ 0ᶠ 0ᶠ)
-                                             (cong replicate 0ᶠ+0ᶠ≡0ᶠ))
+  0ₗₘ : m ⊸ n
+  0ₗₘ {n = n} = record
+    { f = f
+    ; f[u+v]≡f[u]+f[v] = f[u+v]≡f[u]+f[v]
     ; f[c*v]≡c*f[v] = λ c v → sym (c∘ⱽ0ᶠⱽ≡0ᶠⱽ c)
     }
+   where
+     f : (Vec A m → Vec A n)
+     f v = replicate n 0ᶠ
+
+     f[u+v]≡f[u]+f[v] : (u v : Vec A m) → f (u +ⱽ v) ≡ f u +ⱽ f v
+     f[u+v]≡f[u]+f[v] u v = sym (trans (zipWith-replicate _+_ 0ᶠ 0ᶠ)
+                                       (cong (replicate n) 0ᶠ+0ᶠ≡0ᶠ))

--- a/src/FLA/Data/Vec/Properties.agda
+++ b/src/FLA/Data/Vec/Properties.agda
@@ -2,7 +2,8 @@
 
 open import Level using (Level)
 
-open import Relation.Binary.PropositionalEquality hiding (Extensionality)
+open import Relation.Binary.PropositionalEquality
+
 open ≡-Reasoning
 
 open import Data.Nat using (ℕ; suc; zero; _+_)


### PR DESCRIPTION
Update to agda stdlib 2.0 by replicate call change

The newer call to replicate converts the size from an implicit argument to an explicit one, so it must be provided now.

Additionally all the warnings in the new standard library from deprecated functions was addressed.

Fixes #50 (@ncfavier)